### PR TITLE
프로젝트 생성과 프로젝트 상세 페이지의 반응형 구현

### DIFF
--- a/app/projects/[id]/_components/ContactCard.tsx
+++ b/app/projects/[id]/_components/ContactCard.tsx
@@ -17,7 +17,7 @@ export default function ContactCard({
 
   return (
     <div className="w-full h-auto p-5 flex flex-col gap-3 border shadow-md rounded-lg">
-      <span className="text-xl pb-3 font-semibold">연락처</span>
+      <span className="text-lg lg:text-xl pb-3 font-semibold">연락처</span>
 
       {email && (
         <div className="flex items-center gap-2">

--- a/app/projects/[id]/_components/Header/KeywordMenubar.tsx
+++ b/app/projects/[id]/_components/Header/KeywordMenubar.tsx
@@ -1,0 +1,43 @@
+import {
+  Menubar,
+  MenubarContent,
+  MenubarItem,
+  MenubarMenu,
+  MenubarTrigger,
+} from "@/components/ui/menubar";
+import { Badge } from "@/components/ui/badge";
+import { ChevronDown } from "lucide-react";
+import KeywordBadge from "@/components/Badge/KeywordBadge";
+import { PublicProjectWithForeignKeys } from "@/lib/apiClientHelper";
+import { ProjectPageMode } from "../../page";
+
+interface KeywordMenubarProps {
+  mode: ProjectPageMode;
+  project: PublicProjectWithForeignKeys;
+}
+
+export default function KeywordMenubar({ mode, project }: KeywordMenubarProps) {
+  return (
+    <Menubar className="lg:hidden h-full p-0 border-none bg-none shadow-none">
+      <MenubarMenu>
+        <MenubarTrigger className="w-full p-0 h-6 sm:h-7 border-none">
+          <Badge className="sm:w-[72px] bg-gray-200 text-black w-14 h-6 text-[11px] p-0 sm:h-7 font-medium sm:text-sm rounded-sm">
+            키워드
+            <ChevronDown size={16} />
+          </Badge>
+        </MenubarTrigger>
+        <MenubarContent>
+          <MenubarItem>
+            {mode === null && (
+              <div className="w-auto h-full flex gap-1 items-center">
+                {project.keywords.map((keyword) => (
+                  <KeywordBadge key={keyword} keyword={keyword} />
+                ))}
+              </div>
+            )}
+          </MenubarItem>
+        </MenubarContent>
+      </MenubarMenu>
+    </Menubar>
+  );
+}

--- a/app/projects/[id]/_components/Header/index.tsx
+++ b/app/projects/[id]/_components/Header/index.tsx
@@ -56,7 +56,7 @@ const ProjectDetailHeader = ({
 
       {/* 메인: 프로젝트 제목 */}
       <ProjectNameForm
-        className="h-16 flex flex-col justify-end border-b-[1px] border-black"
+        className="h-10 md:h-12 lg:h-16 flex flex-col justify-end border-b-[1px] border-black"
         control={control}
         mode={mode}
       />

--- a/app/projects/[id]/_components/Header/index.tsx
+++ b/app/projects/[id]/_components/Header/index.tsx
@@ -7,16 +7,9 @@ import ProjectNameForm from "@/components/Project/Form/ProjectNameForm";
 import { PublicProjectWithForeignKeys } from "@/lib/apiClientHelper";
 import { parseDate } from "@/lib/utils";
 import { ProjectInput } from "@/types/project";
-import { Calendar, ChevronDown, Eye } from "lucide-react";
+import { Calendar, Eye } from "lucide-react";
 import { Control } from "react-hook-form";
-import {
-  Menubar,
-  MenubarContent,
-  MenubarItem,
-  MenubarMenu,
-  MenubarTrigger,
-} from "@/components/ui/menubar";
-import { Badge } from "@/components/ui/badge";
+import KeywordMenubar from "./KeywordMenubar";
 
 interface ProjectDetailHeaderProps {
   project: PublicProjectWithForeignKeys;
@@ -50,29 +43,7 @@ const ProjectDetailHeader = ({
               ))}
             </div>
           )}
-          {mode === null && (
-            <Menubar className="lg:hidden h-full p-0 border-none bg-none shadow-none">
-              <MenubarMenu>
-                <MenubarTrigger className="w-full p-0 h-6 sm:h-7 border-none">
-                  <Badge className="sm:w-[72px] bg-gray-200 text-black w-14 h-6 text-[11px] p-0 sm:h-7 font-medium sm:text-sm rounded-sm">
-                    키워드
-                    <ChevronDown size={16} />
-                  </Badge>
-                </MenubarTrigger>
-                <MenubarContent>
-                  <MenubarItem>
-                    {mode === null && (
-                      <div className="w-auto h-full flex gap-1 items-center">
-                        {project.keywords.map((keyword) => (
-                          <KeywordBadge key={keyword} keyword={keyword} />
-                        ))}
-                      </div>
-                    )}
-                  </MenubarItem>
-                </MenubarContent>
-              </MenubarMenu>
-            </Menubar>
-          )}
+          {mode === null && <KeywordMenubar mode={mode} project={project} />}
         </div>
 
         <div className="flex gap-x-2 items-center">

--- a/app/projects/[id]/_components/Header/index.tsx
+++ b/app/projects/[id]/_components/Header/index.tsx
@@ -7,8 +7,16 @@ import ProjectNameForm from "@/components/Project/Form/ProjectNameForm";
 import { PublicProjectWithForeignKeys } from "@/lib/apiClientHelper";
 import { parseDate } from "@/lib/utils";
 import { ProjectInput } from "@/types/project";
-import { Calendar, Eye } from "lucide-react";
+import { Calendar, ChevronDown, Eye } from "lucide-react";
 import { Control } from "react-hook-form";
+import {
+  Menubar,
+  MenubarContent,
+  MenubarItem,
+  MenubarMenu,
+  MenubarTrigger,
+} from "@/components/ui/menubar";
+import { Badge } from "@/components/ui/badge";
 
 interface ProjectDetailHeaderProps {
   project: PublicProjectWithForeignKeys;
@@ -30,17 +38,40 @@ const ProjectDetailHeader = ({
     <div className={className}>
       {/* 최상단: 프로젝트 뱃지, 키워드, 관리자 스위치 */}
       <div className="flex justify-between items-center">
-        <div className="flex w-full gap-[10px] items-center h-7 ">
+        <div className="flex w-full gap-[8px] items-center h-7 ">
           <ApplyStatueBadge status={projectStatus} />
           {mode === null && (
             <ProposalBadge proposerType={project.proposerType} />
           )}
           {mode === null && (
-            <div className="w-auto h-full flex gap-1 items-center">
+            <div className="w-auto hidden h-full lg:flex gap-1 items-center">
               {project.keywords.map((keyword) => (
                 <KeywordBadge key={keyword} keyword={keyword} />
               ))}
             </div>
+          )}
+          {mode === null && (
+            <Menubar className="lg:hidden h-full p-0 border-none bg-none shadow-none">
+              <MenubarMenu>
+                <MenubarTrigger className="w-full p-0 h-6 sm:h-7 border-none">
+                  <Badge className="sm:w-[72px] bg-gray-200 text-black w-14 h-6 text-[11px] p-0 sm:h-7 font-medium sm:text-sm rounded-sm">
+                    키워드
+                    <ChevronDown size={16} />
+                  </Badge>
+                </MenubarTrigger>
+                <MenubarContent>
+                  <MenubarItem>
+                    {mode === null && (
+                      <div className="w-auto h-full flex gap-1 items-center">
+                        {project.keywords.map((keyword) => (
+                          <KeywordBadge key={keyword} keyword={keyword} />
+                        ))}
+                      </div>
+                    )}
+                  </MenubarItem>
+                </MenubarContent>
+              </MenubarMenu>
+            </Menubar>
           )}
         </div>
 

--- a/app/projects/[id]/_components/MajorGraph.tsx
+++ b/app/projects/[id]/_components/MajorGraph.tsx
@@ -63,7 +63,7 @@ export default function MajorGraph({
         className
       )}
     >
-      <span className="text-xl font-semibold">팀 현황</span>
+      <span className="text-lg lg:text-xl font-semibold">팀 현황</span>
       {/* 유저 아이콘 */}
       <div className="w-full justify-between flex">
         {majors.map((major, i) => (

--- a/app/projects/[id]/_components/MobileTab.tsx
+++ b/app/projects/[id]/_components/MobileTab.tsx
@@ -1,0 +1,109 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ProjectPageModeEnum } from "./constants";
+import ProjectProposerForm from "@/components/Project/Form/ProjectProposerForm";
+import ProjectForm from "@/components/Project/Form/ProjectForm";
+import CancelAndSubmitButton from "@/components/Project/Form/CancelAndSubmitButton";
+import ContactCard from "./ContactCard";
+import MajorGraph from "./MajorGraph";
+import Chat from "./RightPanel/Chat";
+import { ProjectPageMode } from "../page";
+import { ProjectInput } from "@/types/project";
+import { Control } from "react-hook-form";
+import {
+  PublicApplicant,
+  PublicProjectWithForeignKeys,
+} from "@/lib/apiClientHelper";
+import { ApplicantStatus } from "@prisma/client";
+import { cn } from "@/lib/utils";
+
+interface MobileTabProps {
+  className?: string;
+  mode: ProjectPageMode;
+  control: Control<ProjectInput>;
+  onDelete: () => void;
+  onToggleClose: () => void;
+  onSubmit: () => void;
+  loading?: boolean;
+  project: PublicProjectWithForeignKeys;
+  applicants?: PublicApplicant[];
+  onApplicantStatusChange: (
+    applicantId: number,
+    status: ApplicantStatus
+  ) => void;
+}
+
+export default function MobileTab({
+  onDelete,
+  onToggleClose,
+  project,
+  className,
+  onApplicantStatusChange,
+  loading,
+  onSubmit,
+  applicants,
+  mode,
+  control,
+}: MobileTabProps) {
+  return (
+    <Tabs defaultValue="프로젝트 정보" className={cn("w-full", className)}>
+      <TabsList className="w-full my-3" defaultValue="프로젝트 정보">
+        <TabsTrigger className="w-1/2" value="프로젝트 정보">
+          프로젝트 정보
+        </TabsTrigger>
+        <TabsTrigger className="w-1/2" value="신청현황">
+          신청현황
+        </TabsTrigger>
+      </TabsList>
+
+      {/* 프로젝트 정보(왼쪽 탭) */}
+
+      <TabsContent value="프로젝트 정보" className="pb-14">
+        <div className="flex flex-col gap-5">
+          <div className="flex flex-col gap-5">
+            {mode === ProjectPageModeEnum.ADMIN && (
+              <ProjectProposerForm variant="sm" control={control} />
+            )}
+            <ProjectForm
+              className="w-full h-full flex flex-col gap-5"
+              mode={mode}
+              control={control}
+              withoutProjectName={true}
+            />
+          </div>
+          {mode === ProjectPageModeEnum.ADMIN && (
+            <CancelAndSubmitButton
+              onDelete={onDelete}
+              onToggleClose={onToggleClose}
+              onSubmit={onSubmit}
+              loading={loading}
+              isProjectClosed={project.status !== "RECRUITING"}
+            />
+          )}
+        </div>
+      </TabsContent>
+
+      {/* 신청현황(오른쪽 탭) */}
+
+      <TabsContent value="신청현황" className="pb-14">
+        <div className="flex flex-col gap-3">
+          {mode === null && (
+            <ContactCard
+              email={project.email || undefined}
+              openChatLink={project.chatLink || undefined}
+              proposerPhone={project.proposerPhone || undefined}
+            />
+          )}
+
+          <MajorGraph applicants={applicants as PublicApplicant[]} />
+          <Chat
+            className="w-full text-sm font-medium flex flex-col shadow-md rounded-lg h-[500px]"
+            project={project}
+            mode={mode}
+            applicants={applicants as PublicApplicant[]}
+            onApplicantStatusChange={onApplicantStatusChange}
+          />
+        </div>
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -2,7 +2,6 @@
 "use client";
 
 import { ProjectPageModeEnum } from "@/app/projects/[id]/_components/constants";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import ProjectDetailHeader from "@/app/projects/[id]/_components/Header";
 import ProjectDetailRightPanel from "@/app/projects/[id]/_components/RightPanel";
 import ProjectForm from "@/components/Project/Form/ProjectForm";
@@ -19,6 +18,7 @@ import { parseAsStringEnum, useQueryState } from "nuqs";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import ProjectApplyButton from "./_components/ApplyButton";
+import MobileTab from "./_components/MobileTab";
 
 export type ProjectPageMode = ProjectPageModeEnum | null;
 
@@ -279,39 +279,37 @@ export default function Project({ params }: { params: { id: string } }) {
 
       {/* Mobile 본문 */}
       <div className="pt-2 lg:hidden flex justify-between">
-        <Tabs defaultValue="프로젝트 정보" className="w-full">
-          <TabsList className="w-full my-3" defaultValue="프로젝트 정보">
-            <TabsTrigger className="w-1/2" value="프로젝트 정보">
-              프로젝트 정보
-            </TabsTrigger>
-            <TabsTrigger className="w-1/2" value="신청현황">
-              신청현황
-            </TabsTrigger>
-          </TabsList>
-          <TabsContent value="프로젝트 정보" className="pb-14">
-            <div className="flex flex-col gap-5">
-              {mode === ProjectPageModeEnum.ADMIN && (
-                <ProjectProposerForm variant="sm" control={control as any} />
-              )}
-              <ProjectForm
-                className="w-full h-full flex flex-col gap-5"
-                mode={mode}
-                control={control as any}
-                withoutProjectName={true}
-              />
-            </div>
-          </TabsContent>
-          <TabsContent value="신청현황">Change your password here.</TabsContent>
-        </Tabs>
+        <MobileTab
+          onApplicantStatusChange={(applicantId, status) => {
+            setApplicants((prev) => {
+              if (!prev) return prev;
+              return prev.map((applicant) => {
+                if (applicant.id === applicantId) {
+                  return {
+                    ...applicant,
+                    status,
+                  };
+                }
+                return applicant;
+              });
+            });
+          }}
+          project={project}
+          onSubmit={handleSubmit(onSuccess, onInvalidSubmit)}
+          onToggleClose={handleToggleClose}
+          onDelete={handleDelete}
+          mode={mode}
+          control={control as any}
+          applicants={applicants as PublicApplicant[]}
+        />
         {mode === null && (
           <ProjectApplyButton
-            className="fixed bottom-2 w-[95%] left-1/2 -translate-x-1/2 z-50"
+            className="fixed bottom-2 w-[95%] max-w-96 left-1/2 -translate-x-1/2 z-50"
             projectId={project.id}
             active={project.status === "RECRUITING"}
             onSuccess={(newApplicant) => {
               setProject((prev) => {
                 if (!prev) return prev;
-
                 // 기존 applicants 배열에 새로운 applicant 추가
                 const updatedApplicants = [...prev.applicants, newApplicant];
 

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { ProjectPageModeEnum } from "@/app/projects/[id]/_components/constants";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import ProjectDetailHeader from "@/app/projects/[id]/_components/Header";
 import ProjectDetailRightPanel from "@/app/projects/[id]/_components/RightPanel";
 import ProjectForm from "@/components/Project/Form/ProjectForm";
@@ -17,6 +18,7 @@ import { useRouter } from "next/navigation";
 import { parseAsStringEnum, useQueryState } from "nuqs";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
+import ProjectApplyButton from "./_components/ApplyButton";
 
 export type ProjectPageMode = ProjectPageModeEnum | null;
 
@@ -205,7 +207,7 @@ export default function Project({ params }: { params: { id: string } }) {
   return (
     <form
       onSubmit={handleSubmit(onSuccess, onInvalidSubmit)}
-      className="my-12 px-5 w-full"
+      className="mx-auto max-w-96 my-6 lg:my-12 px-0 lg:px-5 lg:max-w-full w-full"
     >
       {/* 헤더 */}
       <ProjectDetailHeader
@@ -215,8 +217,8 @@ export default function Project({ params }: { params: { id: string } }) {
         toggleMode={toggleMode}
       />
 
-      {/* 본문 */}
-      <div className="w-full pt-5 flex justify-between">
+      {/* Desktop 본문 */}
+      <div className="w-full pt-5 lg:flex hidden justify-between">
         {/* 좌측 */}
         <div className="w-[70%] pr-5 pt-5 flex flex-col gap-5">
           {mode === ProjectPageModeEnum.ADMIN && (
@@ -273,6 +275,60 @@ export default function Project({ params }: { params: { id: string } }) {
           }}
           applicants={applicants}
         />
+      </div>
+
+      {/* Mobile 본문 */}
+      <div className="pt-2 lg:hidden flex justify-between">
+        <Tabs defaultValue="프로젝트 정보" className="w-full">
+          <TabsList className="w-full my-3" defaultValue="프로젝트 정보">
+            <TabsTrigger className="w-1/2" value="프로젝트 정보">
+              프로젝트 정보
+            </TabsTrigger>
+            <TabsTrigger className="w-1/2" value="신청현황">
+              신청현황
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="프로젝트 정보" className="pb-14">
+            <div className="flex flex-col gap-5">
+              {mode === ProjectPageModeEnum.ADMIN && (
+                <ProjectProposerForm variant="sm" control={control as any} />
+              )}
+              <ProjectForm
+                className="w-full h-full flex flex-col gap-5"
+                mode={mode}
+                control={control as any}
+                withoutProjectName={true}
+              />
+            </div>
+          </TabsContent>
+          <TabsContent value="신청현황">Change your password here.</TabsContent>
+        </Tabs>
+        {mode === null && (
+          <ProjectApplyButton
+            className="fixed bottom-2 w-[95%] left-1/2 -translate-x-1/2 z-50"
+            projectId={project.id}
+            active={project.status === "RECRUITING"}
+            onSuccess={(newApplicant) => {
+              setProject((prev) => {
+                if (!prev) return prev;
+
+                // 기존 applicants 배열에 새로운 applicant 추가
+                const updatedApplicants = [...prev.applicants, newApplicant];
+
+                return {
+                  ...prev,
+                  applicants: updatedApplicants,
+                };
+              });
+
+              // applicants 상태도 별도로 업데이트
+              setApplicants((prev) => {
+                if (!prev) return [newApplicant];
+                return [...prev, newApplicant];
+              });
+            }}
+          />
+        )}
       </div>
     </form>
   );

--- a/app/projects/create/page.tsx
+++ b/app/projects/create/page.tsx
@@ -4,6 +4,7 @@ import { ProjectPageModeEnum } from "@/app/projects/[id]/_components/constants";
 import ProjectCreateRightPanel from "@/app/projects/create/_components/RightPanel";
 import ProjectForm from "@/components/Project/Form/ProjectForm";
 import ProjectNameForm from "@/components/Project/Form/ProjectNameForm";
+import { Separator } from "@/components/ui/separator";
 import apiClient from "@/lib/apiClientHelper";
 import { ProjectInput, ProjectSchema } from "@/types/project";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -40,11 +41,11 @@ export default function Create() {
   }
 
   return (
-    <form className="px-5 pb-16 flex flex-col mt-12 gap-5 justify-center w-full">
+    <form className="px-1 lg:px-5 pb-16 flex mx-auto flex-col mt-8 lg:mt-12 gap-5 justify-center max-w-96 lg:max-w-none">
       <ProjectNameForm
         control={control}
         mode={ProjectPageModeEnum.ADMIN}
-        className="h-16 border-b-[1px] border-black"
+        className="h-10 text-lg lg:text-3xl lg:h-16 border-b-[1px] border-black"
       />
 
       {/* <Controller
@@ -52,8 +53,8 @@ export default function Create() {
         control={control}
         render={({ field }) => <FileInput className="px-5 w-full" {...field} />}
       /> */}
-      <div className="w-full mt-5 flex justify-center">
-        <div className="w-[70%] pr-5">
+      <div className="w-full lg:mt-5 flex-col lg:flex-row gap-6 lg:gap-0 flex justify-center">
+        <div className="w-full lg:w-[70%] lg:pr-5">
           <ProjectForm
             mode={ProjectPageModeEnum.ADMIN}
             className="h-full flex flex-col gap-5"
@@ -61,7 +62,7 @@ export default function Create() {
           />
         </div>
         <ProjectCreateRightPanel
-          className="w-[30%]"
+          className="w-full lg:w-[30%]"
           control={control}
           onSubmit={handleSubmit(onSuccess, onInvalidSubmit)}
           loading={loading}

--- a/app/projects/create/page.tsx
+++ b/app/projects/create/page.tsx
@@ -4,7 +4,6 @@ import { ProjectPageModeEnum } from "@/app/projects/[id]/_components/constants";
 import ProjectCreateRightPanel from "@/app/projects/create/_components/RightPanel";
 import ProjectForm from "@/components/Project/Form/ProjectForm";
 import ProjectNameForm from "@/components/Project/Form/ProjectNameForm";
-import { Separator } from "@/components/ui/separator";
 import apiClient from "@/lib/apiClientHelper";
 import { ProjectInput, ProjectSchema } from "@/types/project";
 import { zodResolver } from "@hookform/resolvers/zod";

--- a/components/Header/BottomHeaderBox.tsx
+++ b/components/Header/BottomHeaderBox.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 
 export default function BottomHeaderBox() {
   return (
-    <div className="w-full h-24 flex flex-col">
+    <div className="w-full h-20 lg:h-24 flex flex-col">
       <div className="flex justify-center w-full h-full border-b-[1px] border-b-gray-300">
         <div className="headerWidth relative h-full lg:mx-5 mx-2 flex max-lg:justify-between items-center">
           <SidebarTrigger className="lg:hidden cursor-pointer" />

--- a/components/Header/TopHeaderBox.tsx
+++ b/components/Header/TopHeaderBox.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export default function TopHeaderBox() {
   return (
-    <div className="justify-center px-6 flex py-1.5 w-full h-10 bg-third">
+    <div className="justify-center hidden px-6 lg:flex py-1.5 w-full h-10 bg-third">
       <div className="flex justify-between h-full container">
         <span className="text-white mt-0.5 text-[15px] lett font-light tracking-[-0.5px]">
           Inspiring Future, Grand Challenge

--- a/components/Project/Form/ProjectForm.tsx
+++ b/components/Project/Form/ProjectForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ProjectPageModeEnum } from "@/app/projects/[id]/_components/constants";
 import ProjectTextArea from "@/app/projects/[id]/_components/ProjectTextArea";
 import { ProjectPageMode } from "@/app/projects/[id]/page";
 import { KeywordInput } from "@/components/Project/KeywordInput";
@@ -20,9 +21,15 @@ interface ProjectBodyProps {
   className?: string;
   mode?: ProjectPageMode;
   control: Control<ProjectInput>;
+  withoutProjectName?: boolean; // 모바일에선 폼에서의 프로젝트 제목 필요없음
 }
 
-const ProjectForm = ({ className, mode, control }: ProjectBodyProps) => {
+const ProjectForm = ({
+  className,
+  mode,
+  control,
+  withoutProjectName = false,
+}: ProjectBodyProps) => {
   return (
     <div
       className={cn(
@@ -30,9 +37,18 @@ const ProjectForm = ({ className, mode, control }: ProjectBodyProps) => {
         "lg:border flex flex-col w-full gap-3 lg:gap-5 rounded-lg lg:shadow-sm lg:p-5"
       )}
     >
-      <span className="text-2xl font-semibold">프로젝트 정보</span>
-
-      <Separator className="w-full lg:hidden" />
+      <span
+        className={cn("text-xl lg:text-2xl font-semibold", {
+          hidden: withoutProjectName && mode !== ProjectPageModeEnum.ADMIN,
+        })}
+      >
+        프로젝트 정보
+      </span>
+      <Separator
+        className={cn("w-full lg:hidden", {
+          hidden: withoutProjectName && mode !== ProjectPageModeEnum.ADMIN,
+        })}
+      />
       {/* 필드: 키워드 */}
       {mode === undefined ||
         (mode !== undefined && mode && (

--- a/components/Project/Form/ProjectForm.tsx
+++ b/components/Project/Form/ProjectForm.tsx
@@ -3,6 +3,7 @@
 import ProjectTextArea from "@/app/projects/[id]/_components/ProjectTextArea";
 import { ProjectPageMode } from "@/app/projects/[id]/page";
 import { KeywordInput } from "@/components/Project/KeywordInput";
+import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
 import { ProjectInput } from "@/types/project";
 import { Control, Controller } from "react-hook-form";
@@ -26,10 +27,12 @@ const ProjectForm = ({ className, mode, control }: ProjectBodyProps) => {
     <div
       className={cn(
         { className },
-        "border flex flex-col w-full gap-5 rounded-lg shadow-sm p-5"
+        "lg:border flex flex-col w-full gap-3 lg:gap-5 rounded-lg lg:shadow-sm lg:p-5"
       )}
     >
       <span className="text-2xl font-semibold">프로젝트 정보</span>
+
+      <Separator className="w-full lg:hidden" />
       {/* 필드: 키워드 */}
       {mode === undefined ||
         (mode !== undefined && mode && (

--- a/components/Project/Form/ProjectNameForm.tsx
+++ b/components/Project/Form/ProjectNameForm.tsx
@@ -26,7 +26,7 @@ const ProjectNameForm = ({
           readOnly={mode === null}
           placeholder="프로젝트 제목"
           className={cn(
-            "text-4xl font-medium text-black w-full h-14 p-1 py-1",
+            "text-2xl md:text-3xl lg:text-4xl font-medium text-black w-full h-14 p-1 py-1",
             mode === ProjectPageModeEnum.ADMIN && "bg-gray-100",
             className,
             fieldState.error && "border-b-destructive"

--- a/components/Project/Form/ProjectProposerForm.tsx
+++ b/components/Project/Form/ProjectProposerForm.tsx
@@ -1,6 +1,7 @@
 import ProjectProposerFormField from "@/components/Project/Form/ProjectProposerFormField";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
 import { ProjectInput } from "@/types/project";
 import { ProposerType } from "@prisma/client";
@@ -33,9 +34,11 @@ const ProjectProposerForm = ({
   variant = "default",
 }: ProjectProposerFormProps) => {
   return (
-    <div className={cn({ className }, "border rounded-lg shadow-sm p-5")}>
-      <h3 className="text-2xl font-semibold mb-6">작성자정보</h3>
-
+    <div
+      className={cn({ className }, "lg:border rounded-lg lg:shadow-sm lg:p-5")}
+    >
+      <h3 className="text-2xl font-semibold mb-3 lg:mb-6">작성자정보</h3>
+      <Separator className="lg:hidden mb-6" />
       <div
         className={cn(
           "grid",

--- a/components/Project/Form/ProjectProposerForm.tsx
+++ b/components/Project/Form/ProjectProposerForm.tsx
@@ -37,7 +37,9 @@ const ProjectProposerForm = ({
     <div
       className={cn({ className }, "lg:border rounded-lg lg:shadow-sm lg:p-5")}
     >
-      <h3 className="text-2xl font-semibold mb-3 lg:mb-6">작성자정보</h3>
+      <h3 className="text-xl lg:text-2xl font-semibold mb-3 lg:mb-6">
+        작성자정보
+      </h3>
       <Separator className="lg:hidden mb-6" />
       <div
         className={cn(

--- a/components/Project/Form/ProjectProposerFormField.tsx
+++ b/components/Project/Form/ProjectProposerFormField.tsx
@@ -33,7 +33,6 @@ const ProjectProposerFormField = ({
               value={field.value || ""}
               fieldState={fieldState}
               {...inputProps}
-              className=""
             />
           )}
         />

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function TabsList({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.2",
     "@radix-ui/react-switch": "^1.2.2",
+    "@radix-ui/react-tabs": "^1.1.12",
     "@radix-ui/react-tooltip": "^1.2.6",
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.49.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@radix-ui/react-switch':
         specifier: ^1.2.2
         version: 1.2.5(@types/react-dom@18.3.7(@types/react@18.3.22))(@types/react@18.3.22)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.12
+        version: 1.1.12(@types/react-dom@18.3.7(@types/react@18.3.22))(@types/react@18.3.22)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-tooltip':
         specifier: ^1.2.6
         version: 1.2.7(@types/react-dom@18.3.7(@types/react@18.3.22))(@types/react@18.3.22)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -714,6 +717,19 @@ packages:
 
   '@radix-ui/react-switch@1.2.5':
     resolution: {integrity: sha512-5ijLkak6ZMylXsaImpZ8u4Rlf5grRmoc0p0QeX9VJtlrM4f5m3nCTX8tWga/zOA8PZYIR/t0p2Mnvd7InrJ6yQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.12':
+    resolution: {integrity: sha512-GTVAlRVrQrSw3cEARM0nAx73ixrWDPNZAruETn3oHCNP6SbZ/hNxdxp+u7VkIEv3/sFoLq1PfcHrl7Pnp0CDpw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3199,6 +3215,22 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.22)(react@18.3.1)
       '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.22)(react@18.3.1)
       '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.22)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.22
+      '@types/react-dom': 18.3.7(@types/react@18.3.22)
+
+  '@radix-ui/react-tabs@1.1.12(@types/react-dom@18.3.7(@types/react@18.3.22))(@types/react@18.3.22)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.22)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.22)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.22)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@18.3.7(@types/react@18.3.22))(@types/react@18.3.22)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.22))(@types/react@18.3.22)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.22))(@types/react@18.3.22)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.22)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:


### PR DESCRIPTION
close #51 

![image](https://github.com/user-attachments/assets/5241cc68-d934-4ab8-92f9-9be8bedf338e)
![image](https://github.com/user-attachments/assets/e66f011a-b438-4e37-a869-a6f56aad7a64)

위와 같이 모바일 환경에서의 UI를 구현했습니다. 키워드 부분이 화면 크기에 적당하게 들어가지 않아서 Shadcn의 Menubar를 활용해서 클릭하면 모든 키워드 뱃지가 보이도록 하였습니다.