### PR TITLE
프로젝트 목록 페이지 컴포넌트 위치와 크기 조정 / 프로젝트 상세페이지 모두에게 신청현황 공개하도록 수정

### DIFF
--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -30,9 +30,8 @@ export async function POST(request: NextRequest) {
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;
-    const queryParams = Object.fromEntries(searchParams.entries());
-
-    const validatedQuery = GetProjectsQuerySchema.parse(queryParams);
+    const queryAsObject = Object.fromEntries(searchParams.entries());
+    const validatedQuery = GetProjectsQuerySchema.parse(queryAsObject);
 
     const result = await getAllProjects(validatedQuery);
     return NextResponse.json(result, { status: 200 });

--- a/app/notice/page.tsx
+++ b/app/notice/page.tsx
@@ -1,3 +1,0 @@
-export default function Notice() {
-  return <></>;
-}

--- a/app/projects/[id]/_components/ContactCard.tsx
+++ b/app/projects/[id]/_components/ContactCard.tsx
@@ -1,23 +1,41 @@
 import { formatPhoneNumber } from "@/lib/phoneUtils";
-import { Mail, MessageSquare, Phone } from "lucide-react";
+import { BookA, Mail, MessageSquare, Phone, User } from "lucide-react";
 import Link from "next/link";
 
 interface ContactCardProps {
   email?: string;
   openChatLink?: string;
   proposerPhone?: string;
+  proposerName?: string;
+  proposerMajor?: string;
 }
 
 export default function ContactCard({
+  proposerName,
   email,
   openChatLink,
   proposerPhone,
+  proposerMajor,
 }: ContactCardProps) {
   const isValidLink = openChatLink?.startsWith("http");
 
   return (
     <div className="w-full h-auto p-5 flex flex-col gap-3 border shadow-md rounded-lg">
-      <span className="text-lg lg:text-xl pb-3 font-semibold">연락처</span>
+      <span className="text-lg lg:text-xl pb-3 font-semibold">제안자</span>
+
+      {proposerName && (
+        <div className="flex items-center gap-2">
+          <User size={24} />
+          <span className="text-sm font-normal">이름: {proposerName}</span>
+        </div>
+      )}
+
+      {proposerMajor && (
+        <div className="flex items-center gap-2">
+          <BookA size={24} />
+          <span className="text-sm font-normal">전공: {proposerMajor}</span>
+        </div>
+      )}
 
       {email && (
         <div className="flex items-center gap-2">

--- a/app/projects/[id]/_components/ContactCard.tsx
+++ b/app/projects/[id]/_components/ContactCard.tsx
@@ -1,11 +1,9 @@
-import { formatPhoneNumber } from "@/lib/phoneUtils";
-import { BookA, Mail, MessageSquare, Phone, User } from "lucide-react";
+import { BookA, Mail, MessageSquare, User } from "lucide-react";
 import Link from "next/link";
 
 interface ContactCardProps {
   email?: string;
   openChatLink?: string;
-  proposerPhone?: string;
   proposerName?: string;
   proposerMajor?: string;
 }
@@ -14,7 +12,6 @@ export default function ContactCard({
   proposerName,
   email,
   openChatLink,
-  proposerPhone,
   proposerMajor,
 }: ContactCardProps) {
   const isValidLink = openChatLink?.startsWith("http");
@@ -62,15 +59,6 @@ export default function ContactCard({
               오픈채팅: {openChatLink}
             </span>
           )}
-        </div>
-      )}
-
-      {proposerPhone && (
-        <div className="flex items-center gap-2">
-          <Phone size={24} />
-          <span className="text-sm font-normal">
-            연락처: {formatPhoneNumber(proposerPhone)}
-          </span>
         </div>
       )}
     </div>

--- a/app/projects/[id]/_components/MobileTab.tsx
+++ b/app/projects/[id]/_components/MobileTab.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/lib/apiClientHelper";
 import { ApplicantStatus } from "@prisma/client";
 import { cn } from "@/lib/utils";
+import ApplicantsManage from "./RightPanel/Chat/ApplicantsManage";
 
 interface MobileTabProps {
   className?: string;
@@ -40,9 +41,9 @@ export default function MobileTab({
   onApplicantStatusChange,
   loading,
   onSubmit,
-  applicants,
   mode,
   control,
+  applicants = [],
 }: MobileTabProps) {
   return (
     <Tabs defaultValue="프로젝트 정보" className={cn("w-full", className)}>
@@ -60,9 +61,6 @@ export default function MobileTab({
       <TabsContent value="프로젝트 정보" className="pb-14">
         <div className="flex flex-col gap-5">
           <div className="flex flex-col gap-5">
-            {mode === ProjectPageModeEnum.ADMIN && (
-              <ProjectProposerForm variant="sm" control={control} />
-            )}
             <ProjectForm
               className="w-full h-full flex flex-col gap-5"
               mode={mode}
@@ -88,20 +86,45 @@ export default function MobileTab({
         <div className="flex flex-col gap-3">
           {mode === null && (
             <ContactCard
+              proposerMajor={project.proposerMajor || undefined}
+              proposerName={project.proposerName || undefined}
               email={project.email || undefined}
               openChatLink={project.chatLink || undefined}
               proposerPhone={project.proposerPhone || undefined}
             />
           )}
-
-          <MajorGraph applicants={applicants as PublicApplicant[]} />
-          <Chat
+          {mode === ProjectPageModeEnum.ADMIN && (
+            <ProjectProposerForm variant="sm" control={control} />
+          )}
+          <div className="w-full h-auto p-5 border shadow-md rounded-lg">
+            <span className="text-lg lg:text-xl pb-3 font-semibold">
+              신청 현황
+            </span>
+            <ApplicantsManage
+              mode={mode}
+              applicants={applicants}
+              projectId={project.id}
+              onApplicantStatusChange={onApplicantStatusChange}
+            />
+          </div>
+          {/* 팀 현황 그래프와 채팅 (잠정적으로 제거) */}
+          {/* <MajorGraph applicants={applicants as PublicApplicant[]} /> */}
+          {/* <Chat
             className="w-full text-sm font-medium flex flex-col shadow-md rounded-lg h-[500px]"
             project={project}
             mode={mode}
             applicants={applicants as PublicApplicant[]}
             onApplicantStatusChange={onApplicantStatusChange}
-          />
+          /> */}
+          {mode === ProjectPageModeEnum.ADMIN && (
+            <CancelAndSubmitButton
+              onDelete={onDelete}
+              onToggleClose={onToggleClose}
+              onSubmit={onSubmit}
+              loading={loading}
+              isProjectClosed={project.status !== "RECRUITING"}
+            />
+          )}
         </div>
       </TabsContent>
     </Tabs>

--- a/app/projects/[id]/_components/MobileTab.tsx
+++ b/app/projects/[id]/_components/MobileTab.tsx
@@ -1,20 +1,18 @@
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { ProjectPageModeEnum } from "./constants";
-import ProjectProposerForm from "@/components/Project/Form/ProjectProposerForm";
-import ProjectForm from "@/components/Project/Form/ProjectForm";
 import CancelAndSubmitButton from "@/components/Project/Form/CancelAndSubmitButton";
-import ContactCard from "./ContactCard";
-import MajorGraph from "./MajorGraph";
-import Chat from "./RightPanel/Chat";
-import { ProjectPageMode } from "../page";
-import { ProjectInput } from "@/types/project";
-import { Control } from "react-hook-form";
+import ProjectForm from "@/components/Project/Form/ProjectForm";
+import ProjectProposerForm from "@/components/Project/Form/ProjectProposerForm";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   PublicApplicant,
   PublicProjectWithForeignKeys,
 } from "@/lib/apiClientHelper";
-import { ApplicantStatus } from "@prisma/client";
 import { cn } from "@/lib/utils";
+import { ProjectInput } from "@/types/project";
+import { ApplicantStatus } from "@prisma/client";
+import { Control } from "react-hook-form";
+import { ProjectPageMode } from "../page";
+import { ProjectPageModeEnum } from "./constants";
+import ContactCard from "./ContactCard";
 import ApplicantsManage from "./RightPanel/Chat/ApplicantsManage";
 
 interface MobileTabProps {
@@ -90,7 +88,6 @@ export default function MobileTab({
               proposerName={project.proposerName || undefined}
               email={project.email || undefined}
               openChatLink={project.chatLink || undefined}
-              proposerPhone={project.proposerPhone || undefined}
             />
           )}
           {mode === ProjectPageModeEnum.ADMIN && (

--- a/app/projects/[id]/_components/RightPanel/Chat/ApplicantsManage/ApplicantRow.tsx
+++ b/app/projects/[id]/_components/RightPanel/Chat/ApplicantsManage/ApplicantRow.tsx
@@ -1,3 +1,4 @@
+import { ProjectPageMode } from "@/app/projects/[id]/page";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -26,6 +27,7 @@ interface ApplicantRowProps {
   handleReject?: (applicantId: number) => void;
   handlePending?: (applicantId: number) => void;
   applicant: PublicApplicantForProject;
+  mode: ProjectPageMode;
 }
 
 const ApplicantRow = ({
@@ -34,6 +36,7 @@ const ApplicantRow = ({
   handleAccept,
   handleReject,
   handlePending,
+  mode,
 }: ApplicantRowProps) => {
   const [open, setOpen] = useState(false);
 
@@ -48,9 +51,16 @@ const ApplicantRow = ({
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <div
+          onClick={(e) => {
+            if (mode === null) {
+              e.preventDefault(); // Dialog 열림 차단
+              e.stopPropagation(); // 추가 이벤트 전파 차단
+            }
+          }}
           className={cn(
-            "rounded-lg shadow-sm flex items-center justify-between px-3 w-full h-[45px] border cursor-pointer",
+            "rounded-lg shadow-sm flex items-center justify-between px-3 w-full h-[45px] border",
             "active:bg-gray-200 hover:bg-gray-100 transition-colors duration-200",
+            mode === null ? "cursor-default" : "cursor-pointer",
             className
           )}
         >
@@ -58,7 +68,7 @@ const ApplicantRow = ({
           <div className="flex-1">
             {applicant.name}({applicant.major})
           </div>
-          <div className="flex gap-x-1">
+          <div className={cn("flex gap-x-1", mode === null ? "hidden" : "")}>
             {handleAccept && (
               <Button
                 onClick={(e) => {
@@ -71,7 +81,7 @@ const ApplicantRow = ({
                 size="sm"
                 variant="secondary"
               >
-                수락
+                승인
               </Button>
             )}
             {handleReject && (
@@ -86,7 +96,7 @@ const ApplicantRow = ({
                 size="sm"
                 variant="destructive"
               >
-                거절
+                반려
               </Button>
             )}
             {handlePending && (
@@ -134,7 +144,7 @@ const ApplicantRow = ({
               }}
               onFocus={(e) => e.target.blur()} // focus 방지
             >
-              수락
+              승인
             </Button>
           )}
           {handleReject && (
@@ -146,7 +156,7 @@ const ApplicantRow = ({
               }}
               onFocus={(e) => e.target.blur()} // focus 방지
             >
-              거절
+              반려
             </Button>
           )}
           {handlePending && (

--- a/app/projects/[id]/_components/RightPanel/Chat/ApplicantsManage/index.tsx
+++ b/app/projects/[id]/_components/RightPanel/Chat/ApplicantsManage/index.tsx
@@ -1,4 +1,5 @@
 import ApplicantRow from "@/app/projects/[id]/_components/RightPanel/Chat/ApplicantsManage/ApplicantRow";
+import { ProjectPageMode } from "@/app/projects/[id]/page";
 import {
   Accordion,
   AccordionContent,
@@ -19,12 +20,15 @@ interface ApplicantGroupProps {
     applicantId: number,
     status: ApplicantStatus
   ) => void;
+  mode: ProjectPageMode;
 }
 
 const ApplicantGroup = ({
+  mode,
   projectId,
   status,
   applicants,
+
   onApplicantStatusChange,
 }: ApplicantGroupProps) => {
   const { password } = useProjectPassword(projectId);
@@ -65,9 +69,9 @@ const ApplicantGroup = ({
   }
 
   const groupAsKorean = {
-    APPROVED: "확정",
+    APPROVED: "승인",
     PENDING: "대기",
-    REJECTED: "거절",
+    REJECTED: "반려",
   };
 
   return (
@@ -83,6 +87,7 @@ const ApplicantGroup = ({
         {applicants.length > 0 ? (
           applicants.map((applicant) => (
             <ApplicantRow
+              mode={mode}
               key={applicant.id}
               applicant={applicant}
               projectId={projectId}
@@ -113,9 +118,11 @@ interface ManageApplicantsProps {
     status: ApplicantStatus
   ) => void;
   applicants: PublicApplicant[];
+  mode: ProjectPageMode;
 }
 
 const ApplicantsManage = ({
+  mode,
   className,
   applicants,
   projectId,
@@ -143,6 +150,7 @@ const ApplicantsManage = ({
         REJECTED: rejectedApplicants,
       }).map(([status, applicants]) => (
         <ApplicantGroup
+          mode={mode}
           key={status}
           projectId={projectId}
           status={status as ApplicantStatus}

--- a/app/projects/[id]/_components/RightPanel/Chat/index.tsx
+++ b/app/projects/[id]/_components/RightPanel/Chat/index.tsx
@@ -54,6 +54,7 @@ const Chat = ({
       {/* 탭: 모집 관리 */}
       {mode === ProjectPageModeEnum.ADMIN && tab === Tab.모집관리 && (
         <ManageApplicants
+          mode={mode}
           className="px-2"
           applicants={applicants}
           projectId={project.id}

--- a/app/projects/[id]/_components/RightPanel/index.tsx
+++ b/app/projects/[id]/_components/RightPanel/index.tsx
@@ -1,7 +1,7 @@
 import ProjectApplyButton from "@/app/projects/[id]/_components/ApplyButton";
 import { ProjectPageModeEnum } from "@/app/projects/[id]/_components/constants";
-import MajorGraph from "@/app/projects/[id]/_components/MajorGraph";
-import Chat from "@/app/projects/[id]/_components/RightPanel/Chat";
+// import MajorGraph from "@/app/projects/[id]/_components/MajorGraph";
+// import Chat from "@/app/projects/[id]/_components/RightPanel/Chat";
 import { ProjectPageMode } from "@/app/projects/[id]/page";
 import CancelAndSubmitButton from "@/components/Project/Form/CancelAndSubmitButton";
 import {
@@ -11,6 +11,7 @@ import {
 import { cn } from "@/lib/utils";
 import { ApplicantStatus } from "@prisma/client";
 import ContactCard from "../ContactCard";
+import ApplicantsManage from "./Chat/ApplicantsManage";
 
 interface ProjectDetailRightPanelProps {
   className?: string;
@@ -61,16 +62,28 @@ const ProjectDetailRightPanel = ({
         />
       )}
 
-      <MajorGraph applicants={applicants} />
+      {/* 신청 현황 */}
+      <div className="w-full h-auto p-5 border shadow-md rounded-lg">
+        <span className="text-lg lg:text-xl pb-3 font-semibold">신청 현황</span>
+        <ApplicantsManage
+          mode={mode}
+          applicants={applicants}
+          projectId={project.id}
+          onApplicantStatusChange={onApplicantStatusChange}
+        />
+      </div>
 
-      {/* 프로젝트 대화방 및 모집관리  */}
-      <Chat
+      {/* 팀 현황 그래프(잠정적으로 제거) */}
+      {/* <MajorGraph applicants={applicants} /> */}
+
+      {/* 프로젝트 대화방 및 모집관리(잠정적으로 제거) */}
+      {/* <Chat
         className="w-full text-sm font-medium flex flex-col shadow-md rounded-lg h-[500px]"
         project={project}
         mode={mode}
         applicants={applicants}
         onApplicantStatusChange={onApplicantStatusChange}
-      />
+      /> */}
 
       {/* <ApplicationStatusCard
         projectId={project.id}

--- a/app/projects/[id]/_components/RightPanel/index.tsx
+++ b/app/projects/[id]/_components/RightPanel/index.tsx
@@ -45,6 +45,8 @@ const ProjectDetailRightPanel = ({
     <div className={cn("flex flex-col gap-5 h-auto pt-5", className)}>
       {mode === null && (
         <ContactCard
+          proposerMajor={project.proposerMajor || undefined}
+          proposerName={project.proposerName || undefined}
           email={project.email || undefined}
           openChatLink={project.chatLink || undefined}
           proposerPhone={project.proposerPhone || undefined}

--- a/app/projects/[id]/_components/RightPanel/index.tsx
+++ b/app/projects/[id]/_components/RightPanel/index.tsx
@@ -50,7 +50,6 @@ const ProjectDetailRightPanel = ({
           proposerName={project.proposerName || undefined}
           email={project.email || undefined}
           openChatLink={project.chatLink || undefined}
-          proposerPhone={project.proposerPhone || undefined}
         />
       )}
 

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -86,7 +86,6 @@ export default function Project({ params }: { params: { id: string } }) {
       proposerName: "",
       proposerType: "STUDENT",
       proposerMajor: "",
-      proposerPhone: "",
       status: "RECRUITING",
     },
   });
@@ -108,7 +107,6 @@ export default function Project({ params }: { params: { id: string } }) {
         proposerName: project.proposerName || "",
         proposerType: project.proposerType || "STUDENT",
         proposerMajor: project.proposerMajor || "",
-        proposerPhone: project.proposerPhone || "",
         email: project.email || undefined,
         chatLink: project.chatLink || undefined,
         status: project.status || "RECRUITING",

--- a/app/projects/create/_components/RightPanel.tsx
+++ b/app/projects/create/_components/RightPanel.tsx
@@ -26,7 +26,7 @@ const ProjectCreateRightPanel = ({
   return (
     <div className={cn("text-lg font-semibold flex flex-col gap-5", className)}>
       <ProjectProposerForm
-        className="p-5 border rounded-lg"
+        className="max-lg:border-0 max-lg:p-0 max-lg:shadow-none rounded-lg"
         control={control}
         variant="sm"
       />

--- a/components/Badge/ProposalBadge.tsx
+++ b/components/Badge/ProposalBadge.tsx
@@ -1,5 +1,6 @@
 import { ProposerType } from "@prisma/client";
 import { Badge } from "../ui/badge";
+import { cn } from "@/lib/utils";
 
 interface ProposalBadgeProps {
   proposerType: ProposerType;
@@ -7,24 +8,33 @@ interface ProposalBadgeProps {
 
 export default function ProposalBadge({ proposerType }: ProposalBadgeProps) {
   let proposerText = "";
-
+  let badgeColor = "";
   switch (proposerType) {
     case ProposerType.PROFESSOR:
       proposerText = "교수제안";
+      badgeColor = "bg-third";
       break;
     case ProposerType.STUDENT:
       proposerText = "학생제안";
+      badgeColor = "bg-teal-800";
       break;
     case ProposerType.HOST:
       proposerText = "융합원제안";
+      badgeColor = "bg-indigo-800";
       break;
     default:
       proposerText = "제안자 없음";
+      badgeColor = "bg-gray-400";
       break;
   }
 
   return (
-    <Badge className="sm:w-[72px] sm:h-7 w-14 h-6 text-[11px] rounded-sm flex justify-center items-center bg-third sm:text-sm font-medium text-white">
+    <Badge
+      className={cn(
+        "sm:w-[72px] sm:h-7 w-14 h-6 text-[11px] rounded-sm flex justify-center items-center sm:text-sm font-medium text-white",
+        badgeColor
+      )}
+    >
       {proposerText}
     </Badge>
   );

--- a/components/Filter/index.tsx
+++ b/components/Filter/index.tsx
@@ -2,9 +2,11 @@
 
 import TabTrigger from "@/components/Filter/TabTrigger";
 import { GetProjectsQuerySchema } from "@/types/project";
-import { parseAsStringEnum, useQueryState } from "nuqs";
+import { parseAsInteger, parseAsStringEnum, useQueryState } from "nuqs";
 import { z } from "zod";
 
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
@@ -12,6 +14,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Semester } from "@/types/project";
 import { ProjectStatus } from "@prisma/client";
 
 const Filter = () => {
@@ -20,10 +23,60 @@ const Filter = () => {
     parseAsStringEnum<ProjectStatus>(Object.values(ProjectStatus))
   );
 
+  const currentYear = new Date().getFullYear();
+
+  const [year, setYear] = useQueryState<number>(
+    "year",
+    parseAsInteger.withDefault(currentYear)
+  );
+  const [semester, setSemester] = useQueryState<Semester>(
+    "semester",
+    parseAsStringEnum<Semester>(Object.values(Semester))
+  );
+
   return (
-    <>
+    <div className="w-full flex gap-x-2 justify-between md:justify-start items-center">
+      {/* 필터 대상: 학기/년도 */}
+      <div className="flex gap-2 items-center">
+        <Label htmlFor="year" className="hidden md:block">
+          년도
+        </Label>
+        <Input
+          type="number"
+          value={year}
+          onChange={(e) => setYear(e.target.valueAsNumber)}
+          className="w-16 px-2 py-1 h-8 text-sm"
+        />
+
+        <Label htmlFor="semester" className="hidden md:block">
+          학기
+        </Label>
+        <Select
+          value={semester ?? "구분 없음"} // null이면 "구분 없음"으로 보여줌
+          onValueChange={(value) => {
+            if (value === "구분 없음") setSemester(null);
+            else setSemester(value as Semester);
+          }}
+        >
+          <SelectTrigger size="sm">
+            <SelectValue placeholder={Semester.FIRST} />
+          </SelectTrigger>
+          <SelectContent>
+            {Object.values(Semester).map((sem) => (
+              <SelectItem key={sem} value={sem}>
+                {sem}
+              </SelectItem>
+            ))}
+            <SelectItem key={null} value="구분 없음">
+              구분 없음
+            </SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* 필터 대상: 상태 */}
       {/* PC : TAP 방식 */}
-      <div className="w-full max-sm:hidden h-10 *:cursor-pointer items-center border-b-[1px] *:border-black border-b-black flex">
+      <div className="flex-1 max-sm:hidden h-10 *:cursor-pointer items-center border-b-[1px] *:border-black border-b-black flex">
         <TabTrigger active={filter === null} onClick={() => setFilter(null)}>
           전체
         </TabTrigger>
@@ -42,8 +95,10 @@ const Filter = () => {
           모집마감
         </TabTrigger>
       </div>
+
       {/* 모바일 : SELECT 방식 */}
-      <div className="w-full h-full min-sm:hidden">
+      <div className="min-sm:hidden flex gap-x-1">
+        <Label htmlFor="status">상태</Label>
         <Select
           value={filter ?? "all"} // null이면 all로 보여줌
           onValueChange={(value) => {
@@ -61,7 +116,7 @@ const Filter = () => {
           </SelectContent>
         </Select>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/components/Header/AppSidebar.tsx
+++ b/components/Header/AppSidebar.tsx
@@ -15,7 +15,6 @@ import { Separator } from "../ui/separator";
 
 const sidebarMenus = [
   { title: "프로젝트", url: "/" },
-  { title: "공지사항", url: "/notice" },
 ];
 
 export function AppSidebar() {

--- a/components/Header/BottomHeaderBox.tsx
+++ b/components/Header/BottomHeaderBox.tsx
@@ -22,10 +22,9 @@ export default function BottomHeaderBox() {
             </span>
           </Link>
           <div></div>
-          <ul className="text-xl gap-20 hidden lg:flex lg:absolute right-0">
+          {/* <ul className="text-xl gap-20 hidden lg:flex lg:absolute right-0">
             <Link href="/">프로젝트</Link>
-            <Link href="/notice">공지사항</Link>
-          </ul>
+          </ul> */}
         </div>
       </div>
     </div>

--- a/components/Home/ProjectCard.tsx
+++ b/components/Home/ProjectCard.tsx
@@ -21,7 +21,7 @@ export default function ProjectCard({ project, className }: ProjectCardProps) {
   return (
     <div
       className={cn(
-        "w-full border-t-[1px] py-2.5 px-1 sm:px-2 md:px-3 lg:px-4 bg-white hover:bg-slate-50 transition-colors duration-200 ease-in-out",
+        "w-full border-t-[1px] relative py-2.5 px-1 sm:px-2 md:px-3 lg:px-4 bg-white hover:bg-slate-50 transition-colors duration-200 ease-in-out",
         className
       )}
     >
@@ -33,11 +33,6 @@ export default function ProjectCard({ project, className }: ProjectCardProps) {
             <ApplyStatueBadge status={projectStatus} />
             <ProposalBadge proposerType={project.proposerType} />
           </div>
-
-          {/* 신청 현황 */}
-          <Badge>
-            {approvedApplicantCount} / {MAX_APPLICANTS}
-          </Badge>
         </div>
 
         {/* 제목 */}
@@ -74,6 +69,10 @@ export default function ProjectCard({ project, className }: ProjectCardProps) {
           </div>
         </div>
       </div>
+      {/* 신청 현황 */}
+      <Badge className="bg-green-400 text-white font-black text-base absolute w-16 h-10 top-1/2 -translate-y-1/2 right-0">
+        {approvedApplicantCount} / {MAX_APPLICANTS}
+      </Badge>
     </div>
   );
 }

--- a/components/Home/ProjectCard.tsx
+++ b/components/Home/ProjectCard.tsx
@@ -70,7 +70,7 @@ export default function ProjectCard({ project, className }: ProjectCardProps) {
         </div>
       </div>
       {/* 신청 현황 */}
-      <Badge className="bg-green-400 text-white font-black text-base absolute w-16 h-10 top-1/2 -translate-y-1/2 right-0">
+      <Badge className="bg-green-400 text-white font-black text-xs lg:text-base absolute w-14 h-6 lg:w-16 lg:h-10 top-1/2 -translate-y-1/2 right-0">
         {approvedApplicantCount} / {MAX_APPLICANTS}
       </Badge>
     </div>

--- a/components/Home/ProjectList.tsx
+++ b/components/Home/ProjectList.tsx
@@ -8,9 +8,9 @@ import { z } from "zod";
 import CustomPagination from "@/components/Pagination";
 import Spinner from "@/components/ui/spinner";
 import ApiClient, { PublicProjectWithForeignKeys } from "@/lib/apiClientHelper";
+import { cn } from "@/lib/utils";
 import { GetProjectsQuerySchema } from "@/types/project";
 import ProjectCard from "./ProjectCard";
-import { cn } from "@/lib/utils";
 
 function safeParseSearchParams<T extends z.ZodTypeAny>(
   searchParams: URLSearchParams,

--- a/components/Home/SearchCreateRow.tsx
+++ b/components/Home/SearchCreateRow.tsx
@@ -28,7 +28,7 @@ export default function SearchCreateRow({ className }: SearchBarProps) {
   };
 
   return (
-    <div className="w-full h-22 sm:h-11 flex-col sm:flex-row flex gap-3">
+    <div className="w-full h-24 sm:h-11 flex-col sm:flex-row flex gap-3">
       <form
         className={cn(
           "relative w-full sm:flex-row flex-col h-full flex items-center gap-3",
@@ -41,31 +41,31 @@ export default function SearchCreateRow({ className }: SearchBarProps) {
           handleSearch(searchValue);
         }}
       >
-        <Input
-          name="search"
-          className="w-full text-sm h-full rounded-md px-11 border-[1px] border-black"
-          placeholder="프로젝트 또는 연구키워드로 검색해보세요"
-          defaultValue={searchQuery || ""}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.preventDefault();
-              handleSearch(e.currentTarget.value);
-            }
-          }}
-        />
-        <Search className="absolute top-1/4 sm:top-1/2 -translate-y-1/2 left-3" />
-        <div className="flex gap-3 sm:w-auto w-full h-full">
+        <Button
+          asChild
+          className="w-full h-10 sm:w-50 sm:h-full bg-green-400 hover:bg-green-500 hover:cursor-pointer"
+        >
+          <Link href="/projects/create">프로젝트 제안</Link>
+        </Button>
+        <div className="relative flex gap-3 w-full sm:flex-1 h-full">
+          <Input
+            name="search"
+            className="w-full text-sm h-full rounded-md px-11 border-[1px] border-black"
+            placeholder="프로젝트 또는 연구키워드로 검색해보세요"
+            defaultValue={searchQuery || ""}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleSearch(e.currentTarget.value);
+              }
+            }}
+          />
+          <Search className="absolute top-1/2 -translate-y-1/2 left-3" />
           <Button
-            className="flex-1 w-24 h-full bg-third hover:bg-third/90 hover:cursor-pointer"
+            className="w-16 sm:w-24 h-full bg-third hover:bg-third/90 hover:cursor-pointer"
             type="submit"
           >
             검색
-          </Button>
-          <Button
-            asChild
-            className="flex-1 w-24 h-full bg-secondary hover:bg-secondary/90 hover:cursor-pointer"
-          >
-            <Link href="/projects/create">생성</Link>
           </Button>
         </div>
       </form>

--- a/components/Project/Form/ProjectForm.tsx
+++ b/components/Project/Form/ProjectForm.tsx
@@ -14,7 +14,7 @@ const fields = [
   { name: "method", label: "프로젝트 실행방법" },
   { name: "objective", label: "프로젝트 목표" },
   { name: "result", label: "프로젝트 기대효과" },
-  { name: "etc", label: "기타사항" },
+  { name: "etc", label: "기타 전달사항" },
 ] as const;
 
 interface ProjectBodyProps {

--- a/components/Project/Form/ProjectProposerForm.tsx
+++ b/components/Project/Form/ProjectProposerForm.tsx
@@ -45,39 +45,6 @@ const ProjectProposerForm = ({
           variant === "default" ? "grid-cols-2 gap-5" : "grid-cols-1 gap-2"
         )}
       >
-        <ProjectProposerFormField
-          name="proposerName"
-          control={control}
-          label="이름"
-          inputProps={{ placeholder: "김학생" }}
-        />
-        <ProjectProposerFormField
-          name="proposerMajor"
-          control={control}
-          label="전공"
-          inputProps={{ placeholder: "예: 전자전기공학부" }}
-        />
-        <ProjectProposerFormField
-          name="password"
-          control={control}
-          label="비밀번호"
-          inputProps={{ type: "password", placeholder: "비밀번호(6자 이상)" }}
-        />
-        <ProjectProposerFormField
-          name="email"
-          control={control}
-          label="이메일"
-          inputProps={{ type: "email", placeholder: "example@domain.com" }}
-        />
-        <ProjectProposerFormField
-          name="chatLink"
-          control={control}
-          label="오픈채팅(선택)"
-          inputProps={{
-            type: "url",
-            placeholder: "https://open.kakao.com/o/example",
-          }}
-        />
         <Controller
           name="proposerType"
           control={control}
@@ -136,6 +103,39 @@ const ProjectProposerForm = ({
               )}
             </div>
           )}
+        />
+        <ProjectProposerFormField
+          name="proposerName"
+          control={control}
+          label="이름"
+          inputProps={{ placeholder: "김학생" }}
+        />
+        <ProjectProposerFormField
+          name="proposerMajor"
+          control={control}
+          label="전공"
+          inputProps={{ placeholder: "전자전기공학부" }}
+        />
+        <ProjectProposerFormField
+          name="password"
+          control={control}
+          label="비밀번호"
+          inputProps={{ type: "password", placeholder: "비밀번호(6자 이상)" }}
+        />
+        <ProjectProposerFormField
+          name="email"
+          control={control}
+          label="이메일"
+          inputProps={{ type: "email", placeholder: "example@domain.com" }}
+        />
+        <ProjectProposerFormField
+          name="chatLink"
+          control={control}
+          label="오픈채팅"
+          inputProps={{
+            type: "url",
+            placeholder: "(선택)",
+          }}
         />
       </div>
     </div>

--- a/components/Project/Form/ProjectProposerForm.tsx
+++ b/components/Project/Form/ProjectProposerForm.tsx
@@ -54,6 +54,12 @@ const ProjectProposerForm = ({
           inputProps={{ placeholder: "김학생" }}
         />
         <ProjectProposerFormField
+          name="proposerMajor"
+          control={control}
+          label="전공"
+          inputProps={{ placeholder: "예: 전자전기공학부" }}
+        />
+        <ProjectProposerFormField
           name="password"
           control={control}
           label="비밀번호"
@@ -74,13 +80,12 @@ const ProjectProposerForm = ({
         <ProjectProposerFormField
           name="chatLink"
           control={control}
-          label="채팅링크"
+          label="오픈채팅(선택)"
           inputProps={{
             type: "url",
             placeholder: "https://open.kakao.com/o/example",
           }}
         />
-
         <Controller
           name="proposerType"
           control={control}

--- a/components/Project/Form/ProjectProposerForm.tsx
+++ b/components/Project/Form/ProjectProposerForm.tsx
@@ -36,8 +36,7 @@ const ProjectProposerForm = ({
   return (
     <div
       className={cn(
-        { className },
-        "border p-5 rounded-lg shadow-md lg:border lg:shadow-sm lg:p-5"
+        "border p-5 rounded-lg shadow-md lg:shadow-sm", className
       )}
     >
       <h3 className="text-xl lg:text-2xl font-semibold mb-3 lg:mb-6">제안자</h3>

--- a/components/Project/Form/ProjectProposerForm.tsx
+++ b/components/Project/Form/ProjectProposerForm.tsx
@@ -35,11 +35,12 @@ const ProjectProposerForm = ({
 }: ProjectProposerFormProps) => {
   return (
     <div
-      className={cn({ className }, "lg:border rounded-lg lg:shadow-sm lg:p-5")}
+      className={cn(
+        { className },
+        "border p-5 rounded-lg shadow-md lg:border lg:shadow-sm lg:p-5"
+      )}
     >
-      <h3 className="text-xl lg:text-2xl font-semibold mb-3 lg:mb-6">
-        작성자정보
-      </h3>
+      <h3 className="text-xl lg:text-2xl font-semibold mb-3 lg:mb-6">제안자</h3>
       <Separator className="lg:hidden mb-6" />
       <div
         className={cn(

--- a/components/Project/Form/ProjectProposerForm.tsx
+++ b/components/Project/Form/ProjectProposerForm.tsx
@@ -35,9 +35,7 @@ const ProjectProposerForm = ({
 }: ProjectProposerFormProps) => {
   return (
     <div
-      className={cn(
-        "border p-5 rounded-lg shadow-md lg:shadow-sm", className
-      )}
+      className={cn("border p-5 rounded-lg shadow-md lg:shadow-sm", className)}
     >
       <h3 className="text-xl lg:text-2xl font-semibold mb-3 lg:mb-6">제안자</h3>
       <Separator className="lg:hidden mb-6" />
@@ -64,12 +62,6 @@ const ProjectProposerForm = ({
           control={control}
           label="비밀번호"
           inputProps={{ type: "password", placeholder: "비밀번호(6자 이상)" }}
-        />
-        <ProjectProposerFormField
-          name="proposerPhone"
-          control={control}
-          label="연락처"
-          inputProps={{ type: "tel", placeholder: "010-1234-5678" }}
         />
         <ProjectProposerFormField
           name="email"

--- a/components/Project/Form/ProjectProposerFormField.tsx
+++ b/components/Project/Form/ProjectProposerFormField.tsx
@@ -20,7 +20,10 @@ const ProjectProposerFormField = ({
 }: ProposerFieldProps) => {
   return (
     <div className={cn("flex items-center", className)}>
-      <label htmlFor={name} className={cn("text-sm font-semibold w-20")}>
+      <label
+        htmlFor={name}
+        className={cn("text-sm text-pretty font-semibold w-20")}
+      >
         {label}
       </label>
       <div>

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,7 +24,6 @@ model Project {
   proposerName    String
   proposerType    ProposerType
   proposerMajor   String?
-  proposerPhone   String
   email           String?
   chatLink        String?
   status          ProjectStatus @default(RECRUITING)

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -235,7 +235,6 @@ async function main() {
       ProposerType.HOST,
     ]),
     proposerMajor: getRandomItem(majors),
-    proposerPhone: `010${getRandomInt(1000, 9999)}${getRandomInt(1000, 9999)}`,
     email: `${getRandomItem(emails)}@${getRandomItem(emailDomains)}`,
     chatLink: `https://chat.${getRandomItem(emailDomains)}`,
     status: ProjectStatus.RECRUITING, // 일단 모든 프로젝트를 OPEN으로 시작

--- a/types/project.ts
+++ b/types/project.ts
@@ -1,4 +1,3 @@
-import { cleanPhoneNumber, validateKoreanPhone } from "@/lib/phoneUtils";
 import { passwordField } from "@/types/utils";
 import { Applicant, Prisma, ProjectStatus, ProposerType } from "@prisma/client";
 import { z } from "zod";
@@ -16,14 +15,6 @@ export const ProjectSchema = z.object({
   proposerName: z.string().min(1, "Proposer name is required."),
   proposerType: z.nativeEnum(ProposerType),
   proposerMajor: z.string().optional(),
-  proposerPhone: z
-    .string()
-    .min(1, "연락처를 입력해주세요")
-    .refine(
-      validateKoreanPhone,
-      "올바른 휴대폰 번호를 입력해주세요 (010-XXXX-XXXX)"
-    )
-    .transform(cleanPhoneNumber), // 저장시 숫자만
   email: z.string().email("Invalid email format").optional(),
   chatLink: z.string().url("Invalid URL format").optional(),
   status: z.nativeEnum(ProjectStatus),
@@ -66,7 +57,6 @@ export const projectPublicSelection: Prisma.ProjectSelect = {
   proposerName: true,
   proposerType: true,
   proposerMajor: true,
-  proposerPhone: true,
   email: true,
   chatLink: true,
   status: true,

--- a/types/project.ts
+++ b/types/project.ts
@@ -2,6 +2,11 @@ import { passwordField } from "@/types/utils";
 import { Applicant, Prisma, ProjectStatus, ProposerType } from "@prisma/client";
 import { z } from "zod";
 
+export enum Semester {
+  FIRST = "1학기",
+  SECOND = "2학기",
+}
+
 export const ProjectSchema = z.object({
   name: z.string().min(1, "Project name is required."),
   background: z.string(),
@@ -36,6 +41,8 @@ export const GetProjectsQuerySchema = z.object({
   proposerType: z.nativeEnum(ProposerType).optional(),
   searchTerm: z.string().optional(),
   status: z.nativeEnum(ProjectStatus).optional(),
+  year: z.coerce.number().int().optional(),
+  semester: z.nativeEnum(Semester).optional(),
 });
 export type GetProjectsQueryInput = z.infer<typeof GetProjectsQuerySchema>;
 


### PR DESCRIPTION
close #54 
close #56 
close #60

## 프로젝트 목록 페이지
<img width="250" height="500" alt="image" src="https://github.com/user-attachments/assets/b06be03c-3ada-44e1-89c7-0e5bf5af8c89" />
<img width="500" height="250" alt="image" src="https://github.com/user-attachments/assets/3c85c817-42e1-4ace-948b-4997845e12de" />

- 프로젝트 목록 페이지에서 프로젝트 생성페이지로 진입하기 위한 버튼의 디자인을 반영하였습니다.
    - '생성' -> '프로젝트 제안'으로 문구 수정
    - 위치를 pc 버전에선 검색창 왼쪽으로, 모바일에서는 가장 첫번째 행 전체를 차지하도록 수정
- 성균융합원이 요청했던 '학년도/학기' 구분을 위한 디자인이 반영되지 않아서 이를 재순이에게 요청할 계획입니다.

## 프로젝트 상세 페이지
<img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/4b1a66ed-3c1b-4a6c-9665-5234355a42cb" />
<img width="500" height="350" alt="image" src="https://github.com/user-attachments/assets/cdc19b83-e77e-4cff-94ef-ad9b413ccbef" />

- 프로젝트 상세페이지도 디자인된 내용을 반영하였습니다.
    - 누구든 프로젝트 참여 현황을 볼 수 있도록 반영

## 그 외
- 그 외에도, 성균융합원이 요청했던 자잘한 문구 수정이나 크기 조정 등을 완료했습니다.
- 기존에 있던 <Chat> 컴포넌트가 이번 업데이트로 쓰이지 않게 된 거 같은데, 이 코드를 어떻게 처리할 지 몰라서 일단 남겨놓았는데 이에 대한 결정이 나면 처리해보겠습니다.
- 프로젝트 엔티티에서 아직 제안자의 전화번호 필드가 남아있는데 이를 삭제해야 할 거 같습니다. DB를 건드리는거 같아서 일단 저는 안건드렸습니다.



