### PR TITLE
이메일 알림 기능 추가

### DIFF
--- a/components/Project/Form/ProjectProposerForm.tsx
+++ b/components/Project/Form/ProjectProposerForm.tsx
@@ -111,12 +111,6 @@ const ProjectProposerForm = ({
           inputProps={{ placeholder: "김학생" }}
         />
         <ProjectProposerFormField
-          name="proposerMajor"
-          control={control}
-          label="전공"
-          inputProps={{ placeholder: "전자전기공학부" }}
-        />
-        <ProjectProposerFormField
           name="password"
           control={control}
           label="비밀번호"

--- a/env.d.ts
+++ b/env.d.ts
@@ -7,6 +7,9 @@ declare global {
 
       NEXT_PUBLIC_SUPABASE_URL: string;
       NEXT_PUBLIC_SUPABASE_ANON_KEY: string;
+
+      EMAIL_SERVER_USER: string;
+      EMAIL_SERVER_PASSWORD: string;
     }
   }
 }

--- a/hooks/useProjectPassword.ts
+++ b/hooks/useProjectPassword.ts
@@ -1,10 +1,14 @@
 import { useEffect, useState } from "react";
 
+const PASSWORD_PREFIX = `currentPassword/`;
+
 const useProjectPassword = (projectId: number) => {
   const [password, setPassword] = useState<string>("");
 
   useEffect(() => {
-    const storedPassword = localStorage.getItem(`currentPassword/${projectId}`);
+    const storedPassword = localStorage.getItem(
+      `${PASSWORD_PREFIX}${projectId}`
+    );
     if (storedPassword) {
       setPassword(storedPassword);
     }
@@ -12,7 +16,7 @@ const useProjectPassword = (projectId: number) => {
 
   const savePassword = (newPassword: string) => {
     setPassword(newPassword);
-    localStorage.setItem(`currentPassword/${projectId}`, newPassword);
+    localStorage.setItem(`${PASSWORD_PREFIX}${projectId}`, newPassword);
   };
 
   return { password, setPassword: savePassword };
@@ -28,7 +32,7 @@ export default useProjectPassword;
 export const useSetProjectPassword = () => {
   return {
     setPassword: (projectId: number, password: string) => {
-      localStorage.setItem(`password/${projectId}`, password);
+      localStorage.setItem(`${PASSWORD_PREFIX}${projectId}`, password);
     },
   };
 };

--- a/lib/email/index.ts
+++ b/lib/email/index.ts
@@ -27,8 +27,11 @@ export default async function sendEmail({
 
   try {
     await transporter.sendMail(mailOptions);
-    console.log("Email sent successfully");
+    console.log(`Email sent to ${to} with subject ${subject}`);
   } catch (error) {
-    console.error("Error sending email:", error);
+    console.error(
+      `Error sending email to ${to} with subject ${subject}`,
+      error
+    );
   }
 }

--- a/lib/email/index.ts
+++ b/lib/email/index.ts
@@ -1,0 +1,34 @@
+import nodemailer from "nodemailer";
+import { MailOptions } from "nodemailer/lib/sendmail-transport";
+
+export default async function sendEmail({
+  to,
+  subject,
+  text,
+}: {
+  to: string;
+  subject: string;
+  text: string;
+}) {
+  const transporter = nodemailer.createTransport({
+    service: "gmail",
+    auth: {
+      user: process.env.EMAIL_SERVER_USER,
+      pass: process.env.EMAIL_SERVER_PASSWORD,
+    },
+  });
+
+  const mailOptions: MailOptions = {
+    from: process.env.EMAIL_SERVER_USER,
+    to,
+    subject,
+    text,
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+    console.log("Email sent successfully");
+  } catch (error) {
+    console.error("Error sending email:", error);
+  }
+}

--- a/lib/email/index.ts
+++ b/lib/email/index.ts
@@ -4,11 +4,11 @@ import { MailOptions } from "nodemailer/lib/sendmail-transport";
 export default async function sendEmail({
   to,
   subject,
-  text,
+  html,
 }: {
   to: string;
   subject: string;
-  text: string;
+  html: string;
 }) {
   const transporter = nodemailer.createTransport({
     service: "gmail",
@@ -22,7 +22,7 @@ export default async function sendEmail({
     from: process.env.EMAIL_SERVER_USER,
     to,
     subject,
-    text,
+    html,
   };
 
   try {

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -5,6 +5,30 @@ type EmailTemplate = {
   html: string;
 };
 
+const projectStatusAsVerboseKorean = (status: ProjectStatus | "DELETED") => {
+  switch (status) {
+    case ProjectStatus.RECRUITING:
+      return "모집 중";
+    case ProjectStatus.CLOSED:
+      return "마감";
+    case "DELETED":
+      return "삭제됨";
+    default:
+      return "알 수 없음";
+  }
+};
+
+const applicantStatusAsVerboseKorean = (status: ApplicantStatus) => {
+  switch (status) {
+    case ApplicantStatus.APPROVED:
+      return "승인";
+    case ApplicantStatus.REJECTED:
+      return "반려";
+    case ApplicantStatus.PENDING:
+      return "대기 중";
+  }
+};
+
 /**
  * 새로운 프로젝트가 생성되었을 때 알림
  */
@@ -77,8 +101,8 @@ const applicantStatusChanged = (
   return {
     subject: `프로젝트 지원 상태 변경: ${project.name}`,
     html: `지원자 ${applicantName}님의 지원 상태가 변경되었습니다.<br><br>
-    - 이전 상태: ${prev}<br>
-    - 현재 상태: ${curr}<br>
+    - 이전 상태: ${applicantStatusAsVerboseKorean(prev)}<br>
+    - 현재 상태: ${applicantStatusAsVerboseKorean(curr)}<br>
     - 프로젝트 링크: <a href="${projectLink}">${projectLink}</a><br>
     - 변경일: ${now}
     `,
@@ -99,8 +123,8 @@ const projectStatusChanged = (
   return {
     subject: `프로젝트 상태 변경: ${project.name}`,
     html: `프로젝트 ${project.name}의 상태가 변경되었습니다.<br><br>
-    - 이전 상태: ${prev}<br>
-    - 현재 상태: ${curr}<br>
+    - 이전 상태: ${projectStatusAsVerboseKorean(prev)}<br>
+    - 현재 상태: ${projectStatusAsVerboseKorean(curr)}<br>
     - 프로젝트 링크: <a href="${projectLink}">${projectLink}</a><br>
     - 변경일: ${now}
     `,

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -8,7 +8,7 @@ type EmailTemplate = {
 /**
  * 새로운 프로젝트가 생성되었을 때 알림
  */
-export const newProjectCreated = (newProject: Project): EmailTemplate => {
+const newProjectCreated = (newProject: Project): EmailTemplate => {
   const {
     id,
     name,
@@ -46,7 +46,7 @@ export const newProjectCreated = (newProject: Project): EmailTemplate => {
 /**
  * 신청자가 프로젝트에 지원했을 때 알림
  */
-export const applicantApplied = (
+const applicantApplied = (
   project: Project,
   applicantName: string
 ): EmailTemplate => {
@@ -65,7 +65,7 @@ export const applicantApplied = (
 /**
  * 신청자의 신청 상태가 변경됐을 때 알림
  */
-export const applicantStatusChanged = (
+const applicantStatusChanged = (
   project: Project,
   applicantName: string,
   prev: ApplicantStatus,
@@ -88,10 +88,10 @@ export const applicantStatusChanged = (
 /**
  * 프로젝트 상태 변경 알림
  */
-export const projectStatusChanged = (
+const projectStatusChanged = (
   project: Project,
   prev: ProjectStatus,
-  curr: ProjectStatus
+  curr: ProjectStatus | "DELETED"
 ) => {
   const projectLink = `${process.env.VERCEL_URL}/projects/${project.id}`;
   const now = new Date().toLocaleString("ko-KR");
@@ -106,3 +106,12 @@ export const projectStatusChanged = (
     `,
   };
 };
+
+const emailTemplates = {
+  newProjectCreated,
+  applicantApplied,
+  applicantStatusChanged,
+  projectStatusChanged,
+};
+
+export default emailTemplates;

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -1,0 +1,108 @@
+import { ApplicantStatus, Project, ProjectStatus } from "@prisma/client";
+
+type EmailTemplate = {
+  subject: string;
+  html: string;
+};
+
+/**
+ * 새로운 프로젝트가 생성되었을 때 알림
+ */
+export const newProjectCreated = (newProject: Project): EmailTemplate => {
+  const {
+    id,
+    name,
+    background,
+    method,
+    objective,
+    result,
+    etc,
+    keywords,
+    proposerName,
+    proposerType,
+    proposerMajor,
+  } = newProject;
+  const now = new Date().toLocaleString("ko-KR");
+  const link = `${process.env.VERCEL_URL}/projects/${id}`;
+
+  return {
+    subject: `신규 프로젝트 생성: ${name}`,
+    html: `새로운 프로젝트가 생성되었습니다.<br><br>
+    - 키워드: ${keywords.join(", ")}<br>
+    - 제안자: ${proposerName} (${proposerType})${
+      proposerMajor ? `, ${proposerMajor}` : ""
+    }<br>
+    - 생성일: ${now}<br>
+    - 프로젝트 링크: <a href="${link}">${link}</a><br>
+    - 추진배경: ${background}<br>
+    - 실행방: ${method}<br>
+    - 목표: ${objective}<br>
+    - 기대효과: ${result}<br>
+    - 기타 전달사항: ${etc}
+    `,
+  };
+};
+
+/**
+ * 신청자가 프로젝트에 지원했을 때 알림
+ */
+export const applicantApplied = (
+  project: Project,
+  applicantName: string
+): EmailTemplate => {
+  const projectLink = `${process.env.VERCEL_URL}/projects/${project.id}`;
+  const now = new Date().toLocaleString("ko-KR");
+
+  return {
+    subject: `프로젝트 지원 알림: ${project.name}`,
+    html: `지원자 ${applicantName}님이 프로젝트에 지원했습니다.<br><br>
+    - 프로젝트 링크: <a href="${projectLink}">${projectLink}</a><br>
+    - 지원일: ${now}
+    `,
+  };
+};
+
+/**
+ * 신청자의 신청 상태가 변경됐을 때 알림
+ */
+export const applicantStatusChanged = (
+  project: Project,
+  applicantName: string,
+  prev: ApplicantStatus,
+  curr: ApplicantStatus
+): EmailTemplate => {
+  const projectLink = `${process.env.VERCEL_URL}/projects/${project.id}`;
+  const now = new Date().toLocaleString("ko-KR");
+
+  return {
+    subject: `프로젝트 지원 상태 변경: ${project.name}`,
+    html: `지원자 ${applicantName}님의 지원 상태가 변경되었습니다.<br><br>
+    - 이전 상태: ${prev}<br>
+    - 현재 상태: ${curr}<br>
+    - 프로젝트 링크: <a href="${projectLink}">${projectLink}</a><br>
+    - 변경일: ${now}
+    `,
+  };
+};
+
+/**
+ * 프로젝트 상태 변경 알림
+ */
+export const projectStatusChanged = (
+  project: Project,
+  prev: ProjectStatus,
+  curr: ProjectStatus
+) => {
+  const projectLink = `${process.env.VERCEL_URL}/projects/${project.id}`;
+  const now = new Date().toLocaleString("ko-KR");
+
+  return {
+    subject: `프로젝트 상태 변경: ${project.name}`,
+    html: `프로젝트 ${project.name}의 상태가 변경되었습니다.<br><br>
+    - 이전 상태: ${prev}<br>
+    - 현재 상태: ${curr}<br>
+    - 프로젝트 링크: <a href="${projectLink}">${projectLink}</a><br>
+    - 변경일: ${now}
+    `,
+  };
+};

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.477.0",
-    "next": "14.2.29",
+    "next": "14.2.31",
+    "nodemailer": "^7.0.5",
     "nuqs": "^2.4.3",
     "react": "^18",
     "react-dom": "^18",
@@ -58,6 +59,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4.0.0",
     "@types/node": "^20.17.23",
+    "@types/nodemailer": "^6.4.17",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "bcryptjs": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,11 +75,14 @@ importers:
         specifier: ^0.477.0
         version: 0.477.0(react@18.3.1)
       next:
-        specifier: 14.2.29
-        version: 14.2.29(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 14.2.31
+        version: 14.2.31(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      nodemailer:
+        specifier: ^7.0.5
+        version: 7.0.5
       nuqs:
         specifier: ^2.4.3
-        version: 2.4.3(next@14.2.29(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 2.4.3(next@14.2.31(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18
         version: 18.3.1
@@ -111,6 +114,9 @@ importers:
       '@types/node':
         specifier: ^20.17.23
         version: 20.17.50
+      '@types/nodemailer':
+        specifier: ^6.4.17
+        version: 6.4.17
       '@types/react':
         specifier: ^18
         version: 18.3.22
@@ -285,62 +291,62 @@ packages:
   '@napi-rs/wasm-runtime@0.2.10':
     resolution: {integrity: sha512-bCsCyeZEwVErsGmyPNSzwfwFn4OdxBj0mmv6hOFucB/k81Ojdu68RbZdxYsRQUPc9l6SU5F/cG+bXgWs3oUgsQ==}
 
-  '@next/env@14.2.29':
-    resolution: {integrity: sha512-UzgLR2eBfhKIQt0aJ7PWH7XRPYw7SXz0Fpzdl5THjUnvxy4kfBk9OU4RNPNiETewEEtaBcExNFNn1QWH8wQTjg==}
+  '@next/env@14.2.31':
+    resolution: {integrity: sha512-X8VxxYL6VuezrG82h0pUA1V+DuTSJp7Nv15bxq3ivrFqZLjx81rfeHMWOE9T0jm1n3DtHGv8gdn6B0T0kr0D3Q==}
 
   '@next/eslint-plugin-next@14.2.29':
     resolution: {integrity: sha512-qpxSYiPNJTr9RzqjGi5yom8AIC8Kgdtw4oNIXAB/gDYMDctmfMEv452FRUhT06cWPgcmSsbZiEPYhbFiQtCWTg==}
 
-  '@next/swc-darwin-arm64@14.2.29':
-    resolution: {integrity: sha512-wWtrAaxCVMejxPHFb1SK/PVV1WDIrXGs9ki0C/kUM8ubKHQm+3hU9MouUywCw8Wbhj3pewfHT2wjunLEr/TaLA==}
+  '@next/swc-darwin-arm64@14.2.31':
+    resolution: {integrity: sha512-dTHKfaFO/xMJ3kzhXYgf64VtV6MMwDs2viedDOdP+ezd0zWMOQZkxcwOfdcQeQCpouTr9b+xOqMCUXxgLizl8Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@14.2.29':
-    resolution: {integrity: sha512-7Z/jk+6EVBj4pNLw/JQrvZVrAh9Bv8q81zCFSfvTMZ51WySyEHWVpwCEaJY910LyBftv2F37kuDPQm0w9CEXyg==}
+  '@next/swc-darwin-x64@14.2.31':
+    resolution: {integrity: sha512-iSavebQgeMukUAfjfW8Fi2Iz01t95yxRl2w2wCzjD91h5In9la99QIDKcKSYPfqLjCgwz3JpIWxLG6LM/sxL4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@14.2.29':
-    resolution: {integrity: sha512-o6hrz5xRBwi+G7JFTHc+RUsXo2lVXEfwh4/qsuWBMQq6aut+0w98WEnoNwAwt7hkEqegzvazf81dNiwo7KjITw==}
+  '@next/swc-linux-arm64-gnu@14.2.31':
+    resolution: {integrity: sha512-XJb3/LURg1u1SdQoopG6jDL2otxGKChH2UYnUTcby4izjM0il7ylBY5TIA7myhvHj9lG5pn9F2nR2s3i8X9awQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@14.2.29':
-    resolution: {integrity: sha512-9i+JEHBOVgqxQ92HHRFlSW1EQXqa/89IVjtHgOqsShCcB/ZBjTtkWGi+SGCJaYyWkr/lzu51NTMCfKuBf7ULNw==}
+  '@next/swc-linux-arm64-musl@14.2.31':
+    resolution: {integrity: sha512-IInDAcchNCu3BzocdqdCv1bKCmUVO/bKJHnBFTeq3svfaWpOPewaLJ2Lu3GL4yV76c/86ZvpBbG/JJ1lVIs5MA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@14.2.29':
-    resolution: {integrity: sha512-B7JtMbkUwHijrGBOhgSQu2ncbCYq9E7PZ7MX58kxheiEOwdkM+jGx0cBb+rN5AeqF96JypEppK6i/bEL9T13lA==}
+  '@next/swc-linux-x64-gnu@14.2.31':
+    resolution: {integrity: sha512-YTChJL5/9e4NXPKW+OJzsQa42RiWUNbE+k+ReHvA+lwXk+bvzTsVQboNcezWOuCD+p/J+ntxKOB/81o0MenBhw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@14.2.29':
-    resolution: {integrity: sha512-yCcZo1OrO3aQ38B5zctqKU1Z3klOohIxug6qdiKO3Q3qNye/1n6XIs01YJ+Uf+TdpZQ0fNrOQI2HrTLF3Zprnw==}
+  '@next/swc-linux-x64-musl@14.2.31':
+    resolution: {integrity: sha512-A0JmD1y4q/9ufOGEAhoa60Sof++X10PEoiWOH0gZ2isufWZeV03NnyRlRmJpRQWGIbRkJUmBo9I3Qz5C10vx4w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@14.2.29':
-    resolution: {integrity: sha512-WnrfeOEtTVidI9Z6jDLy+gxrpDcEJtZva54LYC0bSKQqmyuHzl0ego+v0F/v2aXq0am67BRqo/ybmmt45Tzo4A==}
+  '@next/swc-win32-arm64-msvc@14.2.31':
+    resolution: {integrity: sha512-nowJ5GbMeDOMzbTm29YqrdrD6lTM8qn2wnZfGpYMY7SZODYYpaJHH1FJXE1l1zWICHR+WfIMytlTDBHu10jb8A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-ia32-msvc@14.2.29':
-    resolution: {integrity: sha512-vkcriFROT4wsTdSeIzbxaZjTNTFKjSYmLd8q/GVH3Dn8JmYjUKOuKXHK8n+lovW/kdcpIvydO5GtN+It2CvKWA==}
+  '@next/swc-win32-ia32-msvc@14.2.31':
+    resolution: {integrity: sha512-pk9Bu4K0015anTS1OS9d/SpS0UtRObC+xe93fwnm7Gvqbv/W1ZbzhK4nvc96RURIQOux3P/bBH316xz8wjGSsA==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@14.2.29':
-    resolution: {integrity: sha512-iPPwUEKnVs7pwR0EBLJlwxLD7TTHWS/AoVZx1l9ZQzfQciqaFEr5AlYzA2uB6Fyby1IF18t4PL0nTpB+k4Tzlw==}
+  '@next/swc-win32-x64-msvc@14.2.31':
+    resolution: {integrity: sha512-LwFZd4JFnMHGceItR9+jtlMm8lGLU/IPkgjBBgYmdYSfalbHCiDpjMYtgDQ2wtwiAOSJOCyFI4m8PikrsDyA6Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -992,6 +998,9 @@ packages:
 
   '@types/node@20.17.50':
     resolution: {integrity: sha512-Mxiq0ULv/zo1OzOhwPqOA13I81CV/W3nvd3ChtQZRT5Cwz3cr0FKo/wMSsbTqL3EXpaBAEQhva2B8ByRkOIh9A==}
+
+  '@types/nodemailer@6.4.17':
+    resolution: {integrity: sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==}
 
   '@types/phoenix@1.6.6':
     resolution: {integrity: sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==}
@@ -2030,8 +2039,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  next@14.2.29:
-    resolution: {integrity: sha512-s98mCOMOWLGGpGOfgKSnleXLuegvvH415qtRZXpSp00HeEgdmrxmwL9cgKU+h4XrhB16zEI5d/7BnkS3ATInsA==}
+  next@14.2.31:
+    resolution: {integrity: sha512-Wyw1m4t8PhqG+or5a1U/Deb888YApC4rAez9bGhHkTsfwAy4SWKVro0GhEx4sox1856IbLhvhce2hAA6o8vkog==}
     engines: {node: '>=18.17.0'}
     hasBin: true
     peerDependencies:
@@ -2047,6 +2056,10 @@ packages:
         optional: true
       sass:
         optional: true
+
+  nodemailer@7.0.5:
+    resolution: {integrity: sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==}
+    engines: {node: '>=6.0.0'}
 
   nuqs@2.4.3:
     resolution: {integrity: sha512-BgtlYpvRwLYiJuWzxt34q2bXu/AIS66sLU1QePIMr2LWkb+XH0vKXdbLSgn9t6p7QKzwI7f38rX3Wl9llTXQ8Q==}
@@ -2778,37 +2791,37 @@ snapshots:
       '@tybys/wasm-util': 0.9.0
     optional: true
 
-  '@next/env@14.2.29': {}
+  '@next/env@14.2.31': {}
 
   '@next/eslint-plugin-next@14.2.29':
     dependencies:
       glob: 10.3.10
 
-  '@next/swc-darwin-arm64@14.2.29':
+  '@next/swc-darwin-arm64@14.2.31':
     optional: true
 
-  '@next/swc-darwin-x64@14.2.29':
+  '@next/swc-darwin-x64@14.2.31':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@14.2.29':
+  '@next/swc-linux-arm64-gnu@14.2.31':
     optional: true
 
-  '@next/swc-linux-arm64-musl@14.2.29':
+  '@next/swc-linux-arm64-musl@14.2.31':
     optional: true
 
-  '@next/swc-linux-x64-gnu@14.2.29':
+  '@next/swc-linux-x64-gnu@14.2.31':
     optional: true
 
-  '@next/swc-linux-x64-musl@14.2.29':
+  '@next/swc-linux-x64-musl@14.2.31':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@14.2.29':
+  '@next/swc-win32-arm64-msvc@14.2.31':
     optional: true
 
-  '@next/swc-win32-ia32-msvc@14.2.29':
+  '@next/swc-win32-ia32-msvc@14.2.31':
     optional: true
 
-  '@next/swc-win32-x64-msvc@14.2.29':
+  '@next/swc-win32-x64-msvc@14.2.31':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -3472,6 +3485,10 @@ snapshots:
   '@types/node@20.17.50':
     dependencies:
       undici-types: 6.19.8
+
+  '@types/nodemailer@6.4.17':
+    dependencies:
+      '@types/node': 20.17.50
 
   '@types/phoenix@1.6.6': {}
 
@@ -4643,9 +4660,9 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@14.2.29(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.31(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@next/env': 14.2.29
+      '@next/env': 14.2.31
       '@swc/helpers': 0.5.5
       busboy: 1.6.0
       caniuse-lite: 1.0.30001718
@@ -4655,25 +4672,27 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.1(react@18.3.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 14.2.29
-      '@next/swc-darwin-x64': 14.2.29
-      '@next/swc-linux-arm64-gnu': 14.2.29
-      '@next/swc-linux-arm64-musl': 14.2.29
-      '@next/swc-linux-x64-gnu': 14.2.29
-      '@next/swc-linux-x64-musl': 14.2.29
-      '@next/swc-win32-arm64-msvc': 14.2.29
-      '@next/swc-win32-ia32-msvc': 14.2.29
-      '@next/swc-win32-x64-msvc': 14.2.29
+      '@next/swc-darwin-arm64': 14.2.31
+      '@next/swc-darwin-x64': 14.2.31
+      '@next/swc-linux-arm64-gnu': 14.2.31
+      '@next/swc-linux-arm64-musl': 14.2.31
+      '@next/swc-linux-x64-gnu': 14.2.31
+      '@next/swc-linux-x64-musl': 14.2.31
+      '@next/swc-win32-arm64-msvc': 14.2.31
+      '@next/swc-win32-ia32-msvc': 14.2.31
+      '@next/swc-win32-x64-msvc': 14.2.31
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
 
-  nuqs@2.4.3(next@14.2.29(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+  nodemailer@7.0.5: {}
+
+  nuqs@2.4.3(next@14.2.31(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
     dependencies:
       mitt: 3.0.1
       react: 18.3.1
     optionalDependencies:
-      next: 14.2.29(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.31(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   object-assign@4.1.1: {}
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,7 +24,7 @@ model Project {
   proposerName    String
   proposerType    ProposerType
   proposerMajor   String?
-  email           String?
+  email           String
   chatLink        String?
   status          ProjectStatus @default(RECRUITING)
   passwordHash    String        @map("password")

--- a/services/applicant.ts
+++ b/services/applicant.ts
@@ -6,6 +6,8 @@ import {
   UnauthorizedError,
   verifyResourcePassword,
 } from "@/lib/authUtils";
+import sendEmail from "@/lib/email";
+import emailTemplates from "@/lib/email/templates";
 import { prisma } from "@/lib/prisma";
 import {
   ApplicantInput,
@@ -45,6 +47,16 @@ export async function applyToProject(
       projectId,
     },
     select: applicantPublicSelection,
+  });
+
+  const applicantAppliedEmail = emailTemplates.applicantApplied(
+    project,
+    createdApplicant.name
+  );
+  sendEmail({
+    to: project.email,
+    subject: applicantAppliedEmail.subject,
+    html: applicantAppliedEmail.html,
   });
   return createdApplicant;
 }
@@ -132,7 +144,6 @@ export async function acceptApplicant(
 ): Promise<ApplicantForProject> {
   const project = await prisma.project.findUnique({
     where: { id: projectId },
-    select: { passwordHash: true },
   });
   if (!project) {
     throw new NotFoundError(`Project with id ${projectId} not found.`);
@@ -188,6 +199,17 @@ export async function acceptApplicant(
     select: applicantPublicSelection,
   });
 
+  const applicantStatusChangedEmail = emailTemplates.applicantStatusChanged(
+    project,
+    updatedApplicant.name,
+    applicant.status,
+    updatedApplicant.status
+  );
+  sendEmail({
+    to: project.email,
+    subject: applicantStatusChangedEmail.subject,
+    html: applicantStatusChangedEmail.html,
+  });
   return updatedApplicant;
 }
 
@@ -198,7 +220,6 @@ export async function rejectApplicant(
 ): Promise<ApplicantForProject> {
   const project = await prisma.project.findUnique({
     where: { id: projectId },
-    select: { passwordHash: true },
   });
   if (!project) {
     throw new NotFoundError(`Project with id ${projectId} not found.`);
@@ -233,6 +254,17 @@ export async function rejectApplicant(
     select: applicantPublicSelection,
   });
 
+  const applicantStatusChangedEmail = emailTemplates.applicantStatusChanged(
+    project,
+    updatedApplicant.name,
+    applicant.status,
+    updatedApplicant.status
+  );
+  sendEmail({
+    to: project.email,
+    subject: applicantStatusChangedEmail.subject,
+    html: applicantStatusChangedEmail.html,
+  });
   return updatedApplicant;
 }
 
@@ -243,7 +275,6 @@ export async function pendingApplicant(
 ): Promise<ApplicantForProject> {
   const project = await prisma.project.findUnique({
     where: { id: projectId },
-    select: { passwordHash: true },
   });
   if (!project) {
     throw new NotFoundError(`Project with id ${projectId} not found.`);
@@ -278,5 +309,16 @@ export async function pendingApplicant(
     select: applicantPublicSelection,
   });
 
+  const applicantStatusChangedEmail = emailTemplates.applicantStatusChanged(
+    project,
+    updatedApplicant.name,
+    applicant.status,
+    updatedApplicant.status
+  );
+  sendEmail({
+    to: project.email,
+    subject: applicantStatusChangedEmail.subject,
+    html: applicantStatusChangedEmail.html,
+  });
   return updatedApplicant;
 }

--- a/services/project.ts
+++ b/services/project.ts
@@ -314,7 +314,10 @@ export async function deleteProject(
   }
   const projectToDelete = await prisma.project.findUnique({
     where: { id },
-    select: projectPublicSelection,
+    select: {
+      ...projectPublicSelection,
+      passwordHash: true, // 비밀번호 해시 포함
+    },
   });
   if (!projectToDelete) {
     throw new NotFoundError("Project not found for deletion.");

--- a/types/project.ts
+++ b/types/project.ts
@@ -20,7 +20,7 @@ export const ProjectSchema = z.object({
   proposerName: z.string().min(1, "Proposer name is required."),
   proposerType: z.nativeEnum(ProposerType),
   proposerMajor: z.string().optional(),
-  email: z.string().email("Invalid email format").optional(),
+  email: z.string().email("Invalid email format"),
   chatLink: z.string().url("Invalid URL format").optional(),
   status: z.nativeEnum(ProjectStatus),
 });


### PR DESCRIPTION
## 기능 설명
Closes #58
다음 시나리오에서 이메일을 전송합니다.
이메일은 간단한 텍스트만 추가했습니다.
<img width="285" height="771" alt="image" src="https://github.com/user-attachments/assets/1b565b90-409f-4d2f-8991-35b75499cb07" />


### 수신자: 성균융합원
- 새로운 프로젝트 생성

### 수신자: 프로젝트 생성자
- 새로운 지원자 추가

### 수신자: 프로젝트 지원자
- 프로젝트 상태 변경(마감/재모집/삭제)
- 지원 상태 변경(승인/대기/반려)

## 추가 안내
- 로컬 환경에서도 이메일을 보내기 위해서는 밑의 두 환경변수를 추가해야 합니다.
  ```bash
  EMAIL_SERVER_USER=
  EMAIL_SERVER_PASSWORD=
  ```
- 프로젝트 생성 시 비밀번호 저장 안되는 버그 해결
- 프로젝트 생성 양식에서 학생이 아닐 때도 전공 필드 표시되는 버그 해결