### PR TITLE
refactor: replace createClient with getServerSupabase in various files

### DIFF
--- a/actions/auth.ts
+++ b/actions/auth.ts
@@ -3,10 +3,10 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
-import { createClient } from "@/utils/supabase/server";
+import { getServerSupabase } from "@/utils/supabase/server";
 
 export async function login(formData: FormData) {
-  const supabase = await createClient();
+  const supabase = await getServerSupabase();
 
   const data = {
     email: formData.get("email") as string,
@@ -24,7 +24,7 @@ export async function login(formData: FormData) {
 }
 
 export async function signup(formData: FormData) {
-  const supabase = await createClient();
+  const supabase = await getServerSupabase();
 
   const data = {
     email: formData.get("email") as string,
@@ -42,7 +42,7 @@ export async function signup(formData: FormData) {
 }
 
 export async function logout() {
-  const supabase = await createClient();
+  const supabase = await getServerSupabase();
   await supabase.auth.signOut();
   revalidatePath("/", "layout");
   redirect("/");

--- a/app/api/posts/[id]/route.ts
+++ b/app/api/posts/[id]/route.ts
@@ -1,8 +1,8 @@
 import { NotFoundError } from "@/lib/errors";
 import { parseAndValidateRequestBody } from "@/lib/routeUtils";
-import { supabase } from "@/lib/supabaseClient";
 import { deletePost, getPostById, updatePost } from "@/services/post";
 import { PostSchema } from "@/types/post";
+import { getServerSupabase } from "@/utils/supabase/server";
 import { NextRequest, NextResponse } from "next/server";
 
 interface RouteContext {
@@ -38,6 +38,7 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
 }
 
 export async function PUT(request: NextRequest, { params }: RouteContext) {
+  const supabase = await getServerSupabase();
   const session = await supabase.auth.getSession();
   if (!session.data.session) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -78,6 +79,7 @@ export async function PUT(request: NextRequest, { params }: RouteContext) {
 }
 
 export async function DELETE(request: NextRequest, { params }: RouteContext) {
+  const supabase = await getServerSupabase();
   const session = await supabase.auth.getSession();
   if (!session.data.session) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/app/api/posts/route.ts
+++ b/app/api/posts/route.ts
@@ -1,11 +1,12 @@
 import { parseAndValidateRequestBody } from "@/lib/routeUtils"; // GET에는 필요 없음
-import { supabase } from "@/lib/supabaseClient";
 import { createPost, getAllPosts } from "@/services/post";
 import { GetPostsQuerySchema, PostSchema } from "@/types/post";
+import { getServerSupabase } from "@/utils/supabase/server";
 import { NextRequest, NextResponse } from "next/server";
 import { ZodError } from "zod";
 
 export async function POST(request: NextRequest) {
+  const supabase = await getServerSupabase();
   const session = await supabase.auth.getSession();
   if (!session.data.session) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -1,7 +1,7 @@
 import { type EmailOtpType } from "@supabase/supabase-js";
 import { type NextRequest } from "next/server";
 
-import { createClient } from "@/utils/supabase/server";
+import { getServerSupabase } from "@/utils/supabase/server";
 import { redirect } from "next/navigation";
 
 export async function GET(request: NextRequest) {
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
   const next = searchParams.get("next") ?? "/";
 
   if (token_hash && type) {
-    const supabase = await createClient();
+    const supabase = await getServerSupabase();
 
     const { error } = await supabase.auth.verifyOtp({
       type,

--- a/app/projects/[id]/_components/RightPanel/Chat/ChatField.tsx
+++ b/app/projects/[id]/_components/RightPanel/Chat/ChatField.tsx
@@ -14,12 +14,12 @@ import { Textarea } from "@/components/ui/textarea";
 import { SCHEMA_NAME } from "@/constants";
 import { useProjectVerification } from "@/contexts/ProjectVerificationContext";
 import { PublicProjectWithForeignKeys } from "@/lib/apiClientHelper";
-import { supabase } from "@/lib/supabaseClient";
 import type {
   ChatItemGroup,
   ChatMessageContent,
   MessageFromDB,
 } from "@/types/chat"; // 타입 정의 경로 확인
+import { getClientSupabase } from "@/utils/supabase/client";
 import { Send } from "lucide-react";
 import { KeyboardEvent, useEffect, useRef, useState } from "react";
 import ChatBubble from "./ChatBubble";
@@ -128,6 +128,8 @@ export default function ChatField({ project }: ChatFieldProps) {
   const [currentMajor, setCurrentMajor] = useState<string>("");
   const [currentNickname, setCurrentNickname] = useState<string>("");
 
+  const supabase = getClientSupabase();
+
   function enterChatRoom(isAdmin: boolean, major: string, nickname: string) {
     let userId = "";
     if (!isAdmin) {
@@ -204,7 +206,7 @@ export default function ChatField({ project }: ChatFieldProps) {
     return () => {
       supabase.removeChannel(channel).catch(console.error);
     };
-  }, [projectId]);
+  }, [projectId, supabase]);
 
   useEffect(() => {
     setDisplayedChats(transformMessagesForDisplay(rawMessages, currentUserId));

--- a/components/Header/TopHeaderBox.tsx
+++ b/components/Header/TopHeaderBox.tsx
@@ -1,9 +1,9 @@
 import { logout } from "@/actions/auth";
-import { createClient } from "@/utils/supabase/server";
+import { getServerSupabase } from "@/utils/supabase/server";
 import Link from "next/link";
 
 export default async function TopHeaderBox() {
-  const supabase = await createClient();
+  const supabase = await getServerSupabase();
   const { data, error } = await supabase.auth.getUser();
 
   return (

--- a/contexts/ProjectVerificationContext.tsx
+++ b/contexts/ProjectVerificationContext.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import apiClient from "@/lib/apiClientHelper";
-import { supabase } from "@/lib/supabaseClient";
+import { getClientSupabase } from "@/utils/supabase/client";
 import { createContext, useContext, useEffect, useRef, useState } from "react";
 
 interface ProjectVerificationContextType {
@@ -37,6 +37,8 @@ export function ProjectVerificationProvider({
   const [isVerified, setIsVerified] = useState<boolean | null>(null);
   const verifyingRef = useRef(false);
   const lastProjectIdRef = useRef<number | null>(null);
+
+  const supabase = getClientSupabase();
 
   const verifyProject = async () => {
     if (verifyingRef.current) return; // 이미 검증 중
@@ -90,7 +92,6 @@ export function ProjectVerificationProvider({
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange(async (event, session) => {
-
       if (event === "SIGNED_IN" && session?.user) {
         // 🔹 로그인 시 즉시 인증됨으로 설정
         setIsVerified(true);

--- a/hooks/use-file.ts
+++ b/hooks/use-file.ts
@@ -1,4 +1,4 @@
-import { supabase } from "@/lib/supabaseClient";
+import { getClientSupabase } from "@/utils/supabase/client";
 import { useCallback, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 
@@ -23,6 +23,7 @@ interface UseFileResult {
 export function useFile({
   bucketName = `web-${process.env.NODE_ENV || "development"}`,
 }: UseFileProps = {}): UseFileResult {
+  const supabase = getClientSupabase();
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isError, setIsError] = useState<Error | null>(null);
 
@@ -77,7 +78,7 @@ export function useFile({
         setIsLoading(false);
       }
     },
-    [bucketName]
+    [bucketName, supabase.storage]
   );
 
   /**
@@ -110,7 +111,7 @@ export function useFile({
         setIsLoading(false);
       }
     },
-    [bucketName]
+    [bucketName, supabase.storage]
   );
 
   /**
@@ -132,7 +133,7 @@ export function useFile({
         return null;
       }
     },
-    [bucketName]
+    [bucketName, supabase.storage]
   );
 
   /**
@@ -165,7 +166,7 @@ export function useFile({
         setIsLoading(false);
       }
     },
-    [bucketName]
+    [bucketName, supabase.storage]
   );
 
   return {

--- a/hooks/use-user.ts
+++ b/hooks/use-user.ts
@@ -1,9 +1,9 @@
-import { createClient } from "@/utils/supabase/client";
+import { getClientSupabase } from "@/utils/supabase/client";
 import { User } from "@supabase/supabase-js";
 import { useEffect, useState } from "react";
 
 const useUser = () => {
-  const supabase = createClient();
+  const supabase = getClientSupabase();
   const [user, setUser] = useState<User | null>(null);
   useEffect(() => {
     const fetchUser = async () => {

--- a/lib/supabaseStorage.ts
+++ b/lib/supabaseStorage.ts
@@ -1,6 +1,7 @@
-import { supabase } from "../lib/supabaseClient";
+import { getClientSupabase } from "@/utils/supabase/client";
 
 export function getStorage() {
+  const supabase = getClientSupabase();
   const storageName =
     process.env.NODE_ENV === "production"
       ? "web-production"

--- a/services/project.ts
+++ b/services/project.ts
@@ -12,7 +12,7 @@ import {
   Semester,
 } from "@/types/project";
 import { PaginatedType, PasswordOmittedType } from "@/types/utils";
-import { createClient } from "@/utils/supabase/server";
+import { getServerSupabase } from "@/utils/supabase/server";
 import { Prisma, Project } from "@prisma/client";
 import bcrypt from "bcryptjs";
 import { NextRequest } from "next/server";
@@ -40,7 +40,7 @@ export async function verifyProjectPermission(
 ): Promise<boolean> {
   try {
     // 1. 관리자인 경우 무조건 통과
-    const supabase = await createClient();
+    const supabase = await getServerSupabase();
     const {
       data: { user },
     } = await supabase.auth.getUser();

--- a/utils/supabase/client.ts
+++ b/utils/supabase/client.ts
@@ -1,8 +1,24 @@
 import { createBrowserClient } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
-export function createClient() {
-  return createBrowserClient(
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let client: SupabaseClient<any, "public" | "dev", any> | null = null;
+
+export function getClientSupabase() {
+  // 🔹 싱글톤 패턴으로 중복 생성 방지
+  if (client) {
+    return client;
+  }
+
+  client = createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    {
+      db: {
+        schema: process.env.NODE_ENV === "production" ? "public" : "dev",
+      },
+    }
   );
+
+  return client;
 }

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,13 +1,16 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 
-export async function createClient() {
+export async function getServerSupabase() {
   const cookieStore = await cookies();
 
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
     {
+      db: {
+        schema: process.env.NODE_ENV === "production" ? "public" : "dev",
+      },
       cookies: {
         getAll() {
           return cookieStore.getAll();


### PR DESCRIPTION
```sh
Multiple GoTrueClient instances detected in the same browser context. It is not an error, but this should be avoided as it may produce undefined behavior when used concurrently under the same storage key.
```

Supabase 클라이언트에 싱글톤 패턴이 적용되지 않아 많은 문제가 발생되고 있습니다.
클라이언트, 서버 각 런타임을 위한 싱글톤 패턴이 적용된 Supabase 클라이언트를 정의합니다.