### PR TITLE
feat: enhance keep-alive monitoring with hourly checks and email alerts

### DIFF
--- a/.github/workflows/supabase-keepalive.yml
+++ b/.github/workflows/supabase-keepalive.yml
@@ -2,8 +2,8 @@ name: Supabase Keep-Alive
 
 on:
   schedule:
-    # 6시간마다 실행 (UTC 기준: 00:00, 06:00, 12:00, 18:00)
-    - cron: "0 */6 * * *"
+    # 1시간마다 실행 (매시 정각)
+    - cron: "0 * * * *"
   workflow_dispatch: # 수동 실행 가능
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,41 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
+### Environment Variables
+
+Create a `.env.local` file in the root directory with the following variables:
+
+```bash
+# Supabase Configuration
+NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+
+# Email Configuration (for notifications)
+EMAIL_HOST=smtp.gmail.com
+EMAIL_PORT=587
+EMAIL_USER=your_email@gmail.com
+EMAIL_PASSWORD=your_app_password
+EMAIL_FROM=your_email@gmail.com
+
+# Admin Emails (comma-separated list for keep-alive failure alerts)
+ADMIN_EMAILS=admin1@example.com,admin2@example.com,admin3@example.com
+
+# Other configurations...
+```
+
+#### Admin Email Alerts
+
+The `ADMIN_EMAILS` environment variable is used for Supabase keep-alive monitoring:
+
+- Accepts multiple email addresses separated by commas
+- All listed administrators will receive immediate alerts when the Supabase connection fails
+- Keep-alive checks run **every hour** (24 times per day) via GitHub Actions
+- Example: `ADMIN_EMAILS=dev@example.com,ops@example.com,manager@example.com`
+
+> **Note:** The automated keep-alive system helps prevent Supabase project from going inactive by sending regular health checks every hour.
+
+### Running the Development Server
+
 First, run the development server:
 
 ```bash

--- a/app/api/cron/keep-alive/route.ts
+++ b/app/api/cron/keep-alive/route.ts
@@ -1,3 +1,5 @@
+import sendEmail from "@/lib/email";
+import emailTemplates from "@/lib/email/templates";
 import { getClientSupabase } from "@/utils/supabase/client";
 import { NextResponse } from "next/server";
 
@@ -7,7 +9,8 @@ import { NextResponse } from "next/server";
  * 이 API는 정기적으로 호출되어 Supabase 데이터베이스에 가벼운 쿼리를 실행하여
  * 프리티어 비활성화 정책에 의한 일시중지를 방지합니다.
  *
- * GitHub Actions workflow에서 6시간마다 실행
+ * GitHub Actions workflow에서 주기적으로 실행
+ * 실패 시 환경 변수에 등록된 모든 관리자에게 즉시 이메일 알림 발송
  */
 export async function GET() {
   const timestamp = new Date().toISOString();
@@ -66,6 +69,48 @@ export async function GET() {
       operations: results,
       environment: process.env.NODE_ENV,
     };
+
+    // 실패 시 모든 관리자에게 즉시 알림 발송
+    if (!isHealthy) {
+      const adminEmails = process.env.ADMIN_EMAILS?.split(",").map((email) =>
+        email.trim()
+      );
+
+      if (adminEmails && adminEmails.length > 0) {
+        const emailTemplate = emailTemplates.supabaseKeepAliveFailed({
+          timestamp,
+          successCount,
+          totalOperations: operations.length,
+          duration,
+          results,
+        });
+
+        // 모든 관리자에게 병렬로 이메일 발송
+        const emailPromises = adminEmails.map((email) =>
+          sendEmail({
+            to: email,
+            subject: emailTemplate.subject,
+            html: emailTemplate.html,
+          }).catch((error) => {
+            console.error(`Failed to send alert email to ${email}:`, error);
+            return { email, error };
+          })
+        );
+
+        try {
+          await Promise.all(emailPromises);
+          console.log(
+            `✉️ Alert emails sent to ${adminEmails.length} administrator(s)`
+          );
+        } catch (emailError) {
+          console.error("Failed to send alert emails:", emailError);
+        }
+      } else {
+        console.warn(
+          "⚠️ No admin emails configured. Set ADMIN_EMAILS environment variable."
+        );
+      }
+    }
 
     if (isHealthy) {
       console.log("✅ Supabase keep-alive successful:", logData);

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -134,11 +134,111 @@ const projectStatusChanged = (
   };
 };
 
+/**
+ * Supabase Keep-Alive 실패 알림
+ */
+const supabaseKeepAliveFailed = (data: {
+  timestamp: string;
+  successCount: number;
+  totalOperations: number;
+  duration: number;
+  results: Array<{
+    table: string;
+    success: boolean;
+    error: string | null;
+  }>;
+}): EmailTemplate => {
+  const { timestamp, successCount, totalOperations, duration, results } = data;
+  const kstTime = new Date(timestamp).toLocaleString("ko-KR", {
+    timeZone: "Asia/Seoul",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+
+  return {
+    subject: "🚨 [긴급] Supabase Keep-Alive 실패 알림",
+    html: `
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <style>
+          body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
+          .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+          .header { background-color: #d32f2f; color: white; padding: 15px; border-radius: 5px; }
+          .content { background-color: #f5f5f5; padding: 20px; margin-top: 20px; border-radius: 5px; }
+          .info-row { margin: 10px 0; }
+          .label { font-weight: bold; color: #555; }
+          .status-list { list-style: none; padding: 0; }
+          .status-item { padding: 10px; margin: 5px 0; border-radius: 3px; }
+          .status-success { background-color: #e8f5e9; color: #2e7d32; }
+          .status-failed { background-color: #ffebee; color: #c62828; }
+          .alert { background-color: #fff3cd; border-left: 4px solid #ffc107; padding: 12px; margin-top: 20px; }
+        </style>
+      </head>
+      <body>
+        <div class="container">
+          <div class="header">
+            <h2 style="margin: 0;">⚠️ Supabase 연결 상태 문제 감지</h2>
+          </div>
+          
+          <div class="content">
+            <div class="info-row">
+              <span class="label">발생 시간:</span> ${kstTime}
+            </div>
+            <div class="info-row">
+              <span class="label">성공률:</span> ${successCount}/${totalOperations} 작업
+            </div>
+            <div class="info-row">
+              <span class="label">응답 시간:</span> ${duration}ms
+            </div>
+            
+            <h3>상세 내역:</h3>
+            <ul class="status-list">
+              ${results
+                .map(
+                  (r) => `
+                <li class="status-item ${
+                  r.success ? "status-success" : "status-failed"
+                }">
+                  <strong>${r.table}:</strong> 
+                  ${
+                    r.success
+                      ? "✅ 성공"
+                      : `❌ 실패 - ${r.error || "알 수 없는 오류"}`
+                  }
+                </li>
+              `
+                )
+                .join("")}
+            </ul>
+            
+            <div class="alert">
+              <strong>⚠️ 조치 필요:</strong>
+              <p>즉시 Supabase 프로젝트 상태를 확인해주세요.</p>
+              <ul>
+                <li>Supabase 대시보드에서 프로젝트 상태 확인</li>
+                <li>데이터베이스 연결 및 권한 확인</li>
+                <li>필요시 프로젝트 재시작 고려</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </body>
+      </html>
+    `,
+  };
+};
+
 const emailTemplates = {
   newProjectCreated,
   applicantApplied,
   applicantStatusChanged,
   projectStatusChanged,
+  supabaseKeepAliveFailed,
 };
 
 export default emailTemplates;


### PR DESCRIPTION
- Update keep-alive cron schedule from every 6 hours to every hour
- Add multi-admin email notification support for keep-alive failures
- Create email template for keep-alive failure alerts
- Remove database logging, use direct email alerts instead
- Update README with hourly monitoring information

Changes:
- Modified GitHub Action cron: '0 */6 * * *' -> '0 * * * *' (24 checks/day)
- Added ADMIN_EMAILS env support (comma-separated list)
- Send immediate alerts to all admins when Supabase connection fails
- Added createKeepAliveFailureEmail() template with detailed error info