### PR TITLE
fix: restore buildable main + correct semester classification

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.49.8",
     "@vercel/analytics": "^1.5.0",
+    "@vercel/functions": "^3.6.0",
     "@vercel/otel": "^2.0.1",
     "@vercel/speed-insights": "^1.2.0",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       '@vercel/analytics':
         specifier: ^1.5.0
         version: 1.5.0(next@14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@vercel/functions':
+        specifier: ^3.6.0
+        version: 3.6.0
       '@vercel/otel':
         specifier: ^2.0.1
         version: 2.0.1(@opentelemetry/api-logs@0.205.0)(@opentelemetry/api@1.9.0)(@opentelemetry/instrumentation@0.205.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-logs@0.205.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))
@@ -1255,6 +1258,19 @@ packages:
       vue-router:
         optional: true
 
+  '@vercel/functions@3.6.0':
+    resolution: {integrity: sha512-Xj68JYqqJwtqFWJN7EWmFN7MOiUjv5whjw48UEKqQbg8r7hRkhuJhncTU0ba3jJCh/wxEuLWckrtsKcrHQraxw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-web-identity': '*'
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-web-identity':
+        optional: true
+
+  '@vercel/oidc@3.4.1':
+    resolution: {integrity: sha512-H6B+/ig/GoahccL3WZjiHayHw1H5KhvTJNceqYulwfK9kkz5iul2hTmYzcJ7tTCQzyd0dutuL9xYFZCyLUqsog==}
+    engines: {node: '>= 20'}
+
   '@vercel/otel@2.0.1':
     resolution: {integrity: sha512-eC8F8t9Ksn6xPBXBef7w2pMVcgjXoUOMJ3gnTs4Yh/zbKSIKfvX17GjyqCODwF9FdbiiPBxLsF8aQxFOtKyiEA==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -1821,11 +1837,12 @@ packages:
   glob@10.3.10:
     resolution: {integrity: sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
@@ -2641,6 +2658,7 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -3895,6 +3913,12 @@ snapshots:
     optionalDependencies:
       next: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
+
+  '@vercel/functions@3.6.0':
+    dependencies:
+      '@vercel/oidc': 3.4.1
+
+  '@vercel/oidc@3.4.1': {}
 
   '@vercel/otel@2.0.1(@opentelemetry/api-logs@0.205.0)(@opentelemetry/api@1.9.0)(@opentelemetry/instrumentation@0.205.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-logs@0.205.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))':
     dependencies:

--- a/services/project.ts
+++ b/services/project.ts
@@ -40,16 +40,27 @@ export async function verifyProjectPermission(
 ): Promise<boolean> {
   try {
     const supabase = await getServerSupabase();
-    const { data: { user } } = await supabase.auth.getUser();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
     if (user) return true;
 
     if (typeof requestOrPassword === "string") {
-      return await ProjectPasswordManager.validateProjectPassword(projectId, requestOrPassword);
+      return await ProjectPasswordManager.validateProjectPassword(
+        projectId,
+        requestOrPassword
+      );
     }
 
-    const cookiePassword = ProjectPasswordManager.getPasswordFromNextRequest(requestOrPassword, projectId);
+    const cookiePassword = ProjectPasswordManager.getPasswordFromNextRequest(
+      requestOrPassword,
+      projectId
+    );
     if (cookiePassword) {
-      return await ProjectPasswordManager.validateProjectPassword(projectId, cookiePassword);
+      return await ProjectPasswordManager.validateProjectPassword(
+        projectId,
+        cookiePassword
+      );
     }
 
     return false;
@@ -61,11 +72,17 @@ export async function verifyProjectPermission(
 
 export async function createProject(data: ProjectInput): Promise<Project> {
   const { password: projectPlainTextPassword, ...projectDataRest } = data;
-  const projectPasswordHash = await bcrypt.hash(projectPlainTextPassword, SALT_ROUNDS);
+
+  const projectPasswordHash = await bcrypt.hash(
+    projectPlainTextPassword,
+    SALT_ROUNDS
+  );
 
   if (data.proposerType === "STUDENT") {
     if (!data.proposerMajor) {
-      throw new BadRequestError("Proposer major is required when proposer type is STUDENT.");
+      throw new BadRequestError(
+        "Proposer major is required when proposer type is STUDENT."
+      );
     }
     const project = await prisma.project.create({
       data: {
@@ -99,6 +116,9 @@ export async function createProject(data: ProjectInput): Promise<Project> {
       },
       select: projectPublicSelection,
     });
+    if (data.proposerType === "HOST") {
+      return project;
+    }
 
     const newProjectCreatedEmail = emailTemplates.newProjectCreated(project);
     sendEmail({
@@ -150,7 +170,9 @@ export async function getAllProjects(
     if (sortBy.includes(".")) {
       const [relation, field] = sortBy.split(".");
       if (relation === "applicants") {
-        orderByConditions.applicants = { _count: sortOrder };
+        orderByConditions.applicants = { [field]: sortOrder };
+      } else {
+        orderByConditions.createdDatetime = "desc";
       }
     } else {
       orderByConditions[sortBy as keyof Prisma.ProjectOrderByWithRelationInput] = sortOrder;
@@ -159,25 +181,29 @@ export async function getAllProjects(
     orderByConditions.createdDatetime = "desc";
   }
 
-  // --- [중요] 학기 날짜 로직 수정 (9월~2월: 차년도 1학기 / 3월~8월: 당해 2학기) ---
+// --- 학기 날짜 로직 수정 (요청하신 기준 적용) ---
   let startDate: Date;
   let endDate: Date;
+  
+  // 사용자가 선택한 연도(예: 2026) 혹은 현재 연도
   const targetYear = year ?? new Date().getFullYear();
 
   if (semester === Semester.FIRST) {
-    // 1학기 기준: 전년도 9월 1일 ~ 해당 연도 2월 말일
-    // 예: 2026년 1학기 조회 시 -> 2025년 9월 1일 ~ 2026년 2월 28/29일
-    startDate = new Date(targetYear - 1, 8, 1); // 전년도 9월(8) 1일
-    endDate = new Date(targetYear, 2, 0, 23, 59, 59, 999); // 당해 3월 0일 = 2월 말일
-  } else if (semester === Semester.SECOND) {
-    // 2학기 기준: 해당 연도 3월 1일 ~ 해당 연도 8월 31일
-    // 예: 2026년 2학기 조회 시 -> 2026년 3월 1일 ~ 2026년 8월 31일
-    startDate = new Date(targetYear, 2, 1); // 당해 3월(2) 1일
-    endDate = new Date(targetYear, 8, 0, 23, 59, 59, 999); // 당해 9월 0일 = 8월 31일
-  } else {
-    // 전체 학년도: 전년도 9월 1일 ~ 당해 8월 31일
-    startDate = new Date(targetYear - 1, 8, 1);
-    endDate = new Date(targetYear, 8, 0, 23, 59, 59, 999);
+    // [1학기 기준] 전년도 10월 1일 ~ 해당 연도 2월 말일
+    // 예: 2026년 1학기 조회 시 -> 2025년 10월 1일 ~ 2026년 2월 28/29일
+    startDate = new Date(targetYear - 1, 9, 1); // targetYear-1년 10월 1일
+    endDate = new Date(targetYear, 2, 0, 23, 59, 59, 999); // targetYear년 3월 0일 = 2월 말일
+  } 
+  else if (semester === Semester.SECOND) {
+    // [2학기 기준] 해당 연도 3월 1일 ~ 해당 연도 9월 30일
+    // 예: 2026년 2학기 조회 시 -> 2026년 3월 1일 ~ 2026년 9월 30일
+    startDate = new Date(targetYear, 2, 1); // targetYear년 3월 1일
+    endDate = new Date(targetYear, 9, 0, 23, 59, 59, 999); // targetYear년 10월 0일 = 9월 30일
+  } 
+  else {
+    // [학기 미지정 시] 해당 학년도 전체 (전년도 10월 1일 ~ 해당 연도 9월 30일)
+    startDate = new Date(targetYear - 1, 9, 1);
+    endDate = new Date(targetYear, 9, 0, 23, 59, 59, 999);
   }
 
   whereConditions.createdDatetime = {
@@ -203,6 +229,7 @@ export async function getAllProjects(
       where: whereConditions,
       select: projectPublicSelection,
     });
+
     const filteredAllProjects = allProjects.filter((project) => project.status === status);
     finalTotalCount = filteredAllProjects.length;
     filteredProjects = filteredAllProjects.slice(skip, skip + take);
@@ -215,12 +242,12 @@ export async function getAllProjects(
     currentPage: page,
     itemsPerPage: limit,
   };
-}
+} // getAllProjects 함수 끝
 
 export async function getProjectById(id: number): Promise<ProjectWithForeignKeys | null> {
   const project = await prisma.project.findUnique({
     where: { id },
-    select: { ...projectPublicSelection, applicants: true },
+    select: projectPublicSelection,
   });
 
   if (project) {
@@ -229,15 +256,128 @@ export async function getProjectById(id: number): Promise<ProjectWithForeignKeys
         where: { id },
         data: { viewCount: { increment: 1 } },
       });
-      return { ...project, viewCount: project.viewCount + 1 } as ProjectWithForeignKeys;
+      return {
+        ...project,
+        viewCount: project.viewCount + 1,
+      } as ProjectWithForeignKeys;
     } catch (error) {
-      console.error(`Failed to increment view count:`, error);
+      console.error(`Failed to increment view count for project ${id}:`, error);
       return project as ProjectWithForeignKeys;
     }
   }
   return null;
 }
 
-export async function updateProject(id: number, data: Omit<ProjectUpdateInput, "currentPassword">): Promise<Project> {
+export async function updateProject(
+  id: number,
+  data: Omit<ProjectUpdateInput, "currentPassword">
+): Promise<Project> {
   const { password: newPlainTextPassword, ...projectDataRest } = data;
-  const projectToUpdate = await prisma.
+  const projectToUpdate = await prisma.project.findUnique({ where: { id } });
+
+  if (!projectToUpdate) throw new NotFoundError("Project not found.");
+
+  let projectPasswordHashToUpdate;
+  if (newPlainTextPassword) {
+    projectPasswordHashToUpdate = await bcrypt.hash(newPlainTextPassword, SALT_ROUNDS);
+  }
+
+  return await prisma.project.update({
+    where: { id },
+    data: {
+      ...projectDataRest,
+      ...(projectPasswordHashToUpdate && { passwordHash: projectPasswordHashToUpdate }),
+    },
+    select: projectPublicSelection,
+  });
+}
+
+export async function deleteProject(id: number): Promise<void> {
+  const projectToDelete = await prisma.project.findUnique({
+    where: { id },
+    include: { applicants: true }
+  });
+
+  if (!projectToDelete) throw new NotFoundError("Project not found for deletion.");
+
+  try {
+    const [_, deletedProject] = await prisma.$transaction([
+      prisma.applicant.deleteMany({ where: { projectId: id } }),
+      prisma.project.delete({ where: { id } }),
+    ]);
+
+    const projectStatusChangedEmail = emailTemplates.projectStatusChanged(
+      deletedProject,
+      projectToDelete.status,
+      "DELETED"
+    );
+    projectToDelete.applicants.forEach((applicant) => {
+      sendEmail({
+        to: applicant.email,
+        subject: projectStatusChangedEmail.subject,
+        html: projectStatusChangedEmail.html,
+      });
+    });
+  } catch (error) {
+    console.error("Error during project deletion transaction:", error);
+    throw new Error("Failed to delete project and associated data.");
+  }
+}
+
+export async function reopenProject(id: number): Promise<Project> {
+  const projectToReopen = await prisma.project.findUnique({
+    where: { id },
+    include: { applicants: true }
+  });
+
+  if (!projectToReopen) throw new NotFoundError("Project not found for reopening.");
+
+  const reopenedProject = await prisma.project.update({
+    where: { id },
+    data: { status: "RECRUITING" },
+    select: projectPublicSelection,
+  });
+
+  const projectStatusChangedEmail = emailTemplates.projectStatusChanged(
+    reopenedProject,
+    projectToReopen.status,
+    reopenedProject.status
+  );
+  reopenedProject.applicants.forEach((applicant: any) => {
+    sendEmail({
+      to: applicant.email,
+      subject: projectStatusChangedEmail.subject,
+      html: projectStatusChangedEmail.html,
+    });
+  });
+  return reopenedProject;
+}
+
+export async function closeProject(id: number): Promise<Project> {
+  const projectToClose = await prisma.project.findUnique({
+    where: { id },
+    include: { applicants: true }
+  });
+
+  if (!projectToClose) throw new NotFoundError("Project not found for closing.");
+
+  const closedProject = await prisma.project.update({
+    where: { id },
+    data: { status: "CLOSED" },
+    select: projectPublicSelection,
+  });
+
+  const projectStatusChangedEmail = emailTemplates.projectStatusChanged(
+    closedProject,
+    projectToClose.status,
+    closedProject.status
+  );
+  closedProject.applicants.forEach((applicant: any) => {
+    sendEmail({
+      to: applicant.email,
+      subject: projectStatusChangedEmail.subject,
+      html: projectStatusChangedEmail.html,
+    });
+  });
+  return closedProject;
+}

--- a/services/project.ts
+++ b/services/project.ts
@@ -240,7 +240,7 @@ export async function getAllProjects(
     currentPage: page,
     itemsPerPage: limit,
   };
-} // getAllProjects 함수 끝
+}
 
 export async function getProjectById(id: number): Promise<ProjectWithForeignKeys | null> {
   const project = await prisma.project.findUnique({

--- a/services/project.ts
+++ b/services/project.ts
@@ -116,6 +116,7 @@ export async function createProject(data: ProjectInput): Promise<Project> {
       },
       select: projectPublicSelection,
     });
+    // HOST(운영진)가 직접 만든 프로젝트는 관리자 자기알림 메일을 생략
     if (data.proposerType === "HOST") {
       return project;
     }

--- a/services/project.ts
+++ b/services/project.ts
@@ -181,29 +181,27 @@ export async function getAllProjects(
     orderByConditions.createdDatetime = "desc";
   }
 
-// --- 학기 날짜 로직 수정 (요청하신 기준 적용) ---
+  // --- [중요] 학기 날짜 로직 (9월~2월: 차년도 1학기 / 3월~8월: 당해 2학기) ---
+  // URP3는 이번 학기에 모집해 다음 학기에 진행할 팀원을 매칭하므로,
+  // 글 작성 시기가 아니라 모집 대상(다음) 학기로 분류한다.
   let startDate: Date;
   let endDate: Date;
-  
-  // 사용자가 선택한 연도(예: 2026) 혹은 현재 연도
   const targetYear = year ?? new Date().getFullYear();
 
   if (semester === Semester.FIRST) {
-    // [1학기 기준] 전년도 10월 1일 ~ 해당 연도 2월 말일
-    // 예: 2026년 1학기 조회 시 -> 2025년 10월 1일 ~ 2026년 2월 28/29일
-    startDate = new Date(targetYear - 1, 9, 1); // targetYear-1년 10월 1일
-    endDate = new Date(targetYear, 2, 0, 23, 59, 59, 999); // targetYear년 3월 0일 = 2월 말일
-  } 
-  else if (semester === Semester.SECOND) {
-    // [2학기 기준] 해당 연도 3월 1일 ~ 해당 연도 9월 30일
-    // 예: 2026년 2학기 조회 시 -> 2026년 3월 1일 ~ 2026년 9월 30일
-    startDate = new Date(targetYear, 2, 1); // targetYear년 3월 1일
-    endDate = new Date(targetYear, 9, 0, 23, 59, 59, 999); // targetYear년 10월 0일 = 9월 30일
-  } 
-  else {
-    // [학기 미지정 시] 해당 학년도 전체 (전년도 10월 1일 ~ 해당 연도 9월 30일)
-    startDate = new Date(targetYear - 1, 9, 1);
-    endDate = new Date(targetYear, 9, 0, 23, 59, 59, 999);
+    // 1학기 기준: 전년도 9월 1일 ~ 해당 연도 2월 말일
+    // 예: 2026년 1학기 조회 시 -> 2025년 9월 1일 ~ 2026년 2월 28/29일
+    startDate = new Date(targetYear - 1, 8, 1); // 전년도 9월(8) 1일
+    endDate = new Date(targetYear, 2, 0, 23, 59, 59, 999); // 당해 3월 0일 = 2월 말일
+  } else if (semester === Semester.SECOND) {
+    // 2학기 기준: 해당 연도 3월 1일 ~ 해당 연도 8월 31일
+    // 예: 2026년 2학기 조회 시 -> 2026년 3월 1일 ~ 2026년 8월 31일
+    startDate = new Date(targetYear, 2, 1); // 당해 3월(2) 1일
+    endDate = new Date(targetYear, 8, 0, 23, 59, 59, 999); // 당해 9월 0일 = 8월 31일
+  } else {
+    // 전체 학년도: 전년도 9월 1일 ~ 당해 8월 31일
+    startDate = new Date(targetYear - 1, 8, 1);
+    endDate = new Date(targetYear, 8, 0, 23, 59, 59, 999);
   }
 
   whereConditions.createdDatetime = {


### PR DESCRIPTION
## 배경
main이 2026-03-31부터 빌드 불가 상태입니다 (CI Build Validation 계속 red). 웹 에디터로 main에 직접 커밋하면서 결함이 들어갔고, webpack이 첫 에러에서 멈추는 탓에 순차로 드러났습니다.

## 변경 사항

### 1. services/project.ts 복원 (빌드 수정)
updateProject 작성 도중 잘려 있던 파일(Unexpected eof)을 마지막 CI 통과 커밋 f164c6c 버전으로 복원. 8개 export 함수 모두 복구.

### 2. @vercel/functions 의존성 추가 (빌드 수정)
services/applicant.ts가 waitUntil을 import하지만 패키지가 package.json에 없어 Module not found. @vercel/functions ^3.6.0 추가.

### 3. 학기 분류 로직 수정 (정확성)
getAllProjects가 글 작성 시기로 학기를 분류했으나, URP3는 이번 학기에 모집해 **다음 학기**에 진행할 팀원을 매칭하므로 대상(다음) 학기로 분류해야 합니다. 잘린 커밋 79ac993에 담겨 있던 9~2월 / 3~8월 기준(URP 담당자 확인)을 적용 — f164c6c의 옛 10월/9월 기준은 9월 작성 글을 오분류했습니다.

## 검증
로컬 pnpm build 성공 — Compiled successfully → 타입 체크 통과 → 정적 페이지 13/13.

## 범위 밖 (의도적 제외)
79ac993에 있던 orderBy `_count`·getProjectById applicants 변경은 미확인 사항이라 제외했습니다 — 필요 시 별도 처리.

Closes #77