### PR TITLE
fix: 보안 취약점 2건 수정 (지원자 자가승인 · posts 인증 우회)

### DIFF
--- a/app/api/posts/[id]/route.ts
+++ b/app/api/posts/[id]/route.ts
@@ -39,8 +39,11 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
 
 export async function PUT(request: NextRequest, { params }: RouteContext) {
   const supabase = await getServerSupabase();
-  const session = await supabase.auth.getSession();
-  if (!session.data.session) {
+  // 서버 인증은 getUser()로 — getSession()은 쿠키를 재검증 없이 신뢰한다.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
@@ -80,8 +83,11 @@ export async function PUT(request: NextRequest, { params }: RouteContext) {
 
 export async function DELETE(request: NextRequest, { params }: RouteContext) {
   const supabase = await getServerSupabase();
-  const session = await supabase.auth.getSession();
-  if (!session.data.session) {
+  // 서버 인증은 getUser()로 — getSession()은 쿠키를 재검증 없이 신뢰한다.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 

--- a/app/api/posts/route.ts
+++ b/app/api/posts/route.ts
@@ -7,8 +7,12 @@ import { ZodError } from "zod";
 
 export async function POST(request: NextRequest) {
   const supabase = await getServerSupabase();
-  const session = await supabase.auth.getSession();
-  if (!session.data.session) {
+  // getSession()은 쿠키 값을 그대로 신뢰하므로 서버 인증에 사용하면 안 된다.
+  // getUser()는 Supabase Auth 서버에 토큰을 재검증한다.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 

--- a/app/projects/[id]/_components/ApplyButton.tsx
+++ b/app/projects/[id]/_components/ApplyButton.tsx
@@ -64,7 +64,6 @@ const ProjectApplyButton = ({
       major: "",
       email: "",
       introduction: "",
-      status: "PENDING",
     },
   });
 

--- a/services/applicant.ts
+++ b/services/applicant.ts
@@ -45,6 +45,7 @@ export async function applyToProject(
     data: {
       ...data,
       projectId,
+      status: "PENDING", // 신규 지원자는 항상 대기 상태로 생성 (자가 승인 방지)
     },
     select: applicantPublicSelection,
   });

--- a/types/applicant.ts
+++ b/types/applicant.ts
@@ -1,12 +1,14 @@
-import { ApplicantStatus, Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import { z } from "zod";
 
+// status는 의도적으로 제외한다. 지원자 상태 전이는 accept/reject/pending
+// 엔드포인트(verifyProjectPermission 보호)로만 가능해야 하며, 클라이언트가
+// 생성/수정 요청 본문으로 status를 지정하지 못하게 한다.
 export const ApplicantSchema = z.object({
   name: z.string().min(1, "Name is required."),
   email: z.string().email("Invalid email format."),
   major: z.string().min(1, "Major is required."),
   introduction: z.string().min(1, "Introduction is required."),
-  status: z.nativeEnum(ApplicantStatus),
 });
 export const ApplicantUpdateSchema = ApplicantSchema;
 export type ApplicantInput = z.infer<typeof ApplicantSchema>;


### PR DESCRIPTION
## 요약

미인증 공격자가 악용 가능한 보안 취약점 **2건**을 수정합니다. 두 건 모두 별도 커밋으로 분리되어 있습니다.

## 수정 내용

### 1. 지원자 자가 승인 — Mass Assignment (HIGH)

`ApplicantSchema`에 `status` 필드가 포함돼 있어, 미인증 사용자가 `POST /api/projects/[id]/apply` 요청 본문에 `status: "APPROVED"`를 넣어 프로젝트 소유자의 승인 절차와 전공 쿼터(`MAX_APPLICANT_MAJOR_COUNT`)를 우회하고 임의 프로젝트에 **자가 승인 가입**할 수 있었습니다.

- `ApplicantSchema`에서 `status` 제거 → Zod `z.object()`가 unknown 키를 스트립
- `applyToProject`가 `status: "PENDING"`을 서버에서 명시 강제 (이중 방어)
- `ApplyButton` 폼의 사용되지 않던 `status` defaultValue 제거
- 부수 효과: `ApplicantUpdateSchema`도 `status`를 더 이상 받지 않음

### 2. posts 인증 우회 — getSession (HIGH)

posts `POST`/`PUT`/`DELETE` 핸들러가 `supabase.auth.getSession()`으로 인증했습니다. `getSession()`은 쿠키 값을 **재검증 없이 신뢰**하므로 위조된 세션 쿠키가 통과할 수 있었습니다. `getUser()`로 교체 — Supabase Auth 서버가 토큰을 재검증합니다.

> 같은 코드베이스의 `verifyProjectPermission`(services/project.ts)와 supabase middleware는 이미 `getUser()`를 사용 중이었고, posts 라우트만 일관성이 깨져 있었습니다.

## 검증

- 수정한 5개 파일: `tsc --noEmit` 타입 에러 **0건**, `eslint` 경고 **0건**
- urp3-team-matching/web#78 (buildable main 복구) 머지 후 rebase 완료 — GitHub Actions `build` 워크플로가 실제 `pnpm next build`를 실행해 **통과** (Vercel 체크는 Ignored Build Step으로 스킵되므로 빌드 검증 신호가 아님)

## 테스트 플랜

- [x] `status: "APPROVED"`로 apply 요청 → 생성된 지원자가 `PENDING`인지 확인 — **로컬 E2E 통과** (Docker Postgres + 실제 apply 호출, 응답·DB 모두 `PENDING`)
- [x] 위조/없는 세션 쿠키로 `POST /api/posts` → `401` 확인 — **통과** (no-cookie 케이스 검증; 위조 쿠키 시나리오는 코드 레벨로만 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
