### PR TITLE
fix: make footer responsive on mobile

### DIFF
--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -3,15 +3,15 @@ export default function Footer() {
     <footer className="w-full bg-[#343338] text-white">
       {/* ✅ 헤더와 동일한 정렬 방식: justify-center + container */}
       <div className="flex w-full justify-center px-6">
-        <div className="container py-10">
-          <div className="flex items-start justify-between gap-10">
+        <div className="container py-8 md:py-10">
+          <div className="flex flex-col items-start gap-8 md:flex-row md:justify-between md:gap-10">
             {/* Left */}
             <div className="min-w-0">
-              <p className="text-[26px] leading-[28px] font-semibold tracking-[0.3px]">
+              <p className="text-[20px] leading-[24px] font-semibold tracking-[0.3px] md:text-[26px] md:leading-[28px]">
                 SUNGKYUNKWAN UNIVERSITY (SKKU)
               </p>
 
-              <p className="mt-[14px] text-[20px] leading-[24px] font-semibold">
+              <p className="mt-[14px] text-[16px] leading-[22px] font-semibold md:text-[20px] md:leading-[24px]">
                 성균관대학교 성균융합원 융합연구학점제
               </p>
 
@@ -26,8 +26,8 @@ export default function Footer() {
             </div>
 
             {/* Right (Email) */}
-            <div className="shrink-0 text-right">
-              <div className="inline-flex items-center justify-center rounded-full border-2 border-white px-[24px] py-[6px] text-[18px] leading-[24px] font-semibold">
+            <div className="shrink-0 md:text-right">
+              <div className="inline-flex items-center justify-center rounded-full border-2 border-white px-5 py-[6px] text-[15px] leading-[24px] font-semibold md:px-[24px] md:text-[18px]">
                 Email : urp3@skku.edu
               </div>
             </div>


### PR DESCRIPTION
## 배경
<img width="780" height="628" alt="footer-mobile" src="https://github.com/user-attachments/assets/a22495d1-8c5c-485b-8bc3-2a51abe728d4" />

성균융합원 담당자 메일 수정 요청 (2026-05-19) — 푸터가 모바일 화면에 맞게 변환되지 않음.

## 변경
components/Footer/index.tsx — 모바일 우선(mobile-first) 반응형 적용:
- 768px(md) 미만: 텍스트 블록과 이메일 알약을 세로로 쌓음(flex-col), 왼쪽 정렬
- 제목/부제목/이메일 알약 폰트를 모바일에서 축소, md: 이상에서 기존 데스크톱 크기 복원
- 데스크톱(≥768px) 레이아웃은 변화 없음

한 파일 CSS 변경입니다.

Closes #76