### PR TITLE
fix: 미인증 viewer 지원자 PII 차단 + 이메일 HTML 인젝션 escape (Vuln 4·3)

### DIFF
--- a/app/api/projects/[id]/applicants/route.ts
+++ b/app/api/projects/[id]/applicants/route.ts
@@ -1,4 +1,5 @@
 import { getApplicantsByProjectId } from "@/services/applicant";
+import { verifyProjectPermission } from "@/services/project";
 import { NextRequest, NextResponse } from "next/server";
 
 interface ProjectContext {
@@ -14,7 +15,9 @@ export async function GET(request: NextRequest, { params }: ProjectContext) {
         { status: 400 }
       );
 
-    const applicants = await getApplicantsByProjectId(projectId);
+    // 인증된 owner에게만 PII(email, introduction) 포함해서 반환
+    const isOwner = await verifyProjectPermission(projectId, request);
+    const applicants = await getApplicantsByProjectId(projectId, isOwner);
     return NextResponse.json(applicants);
   } catch (error) {
     console.error(`Error fetching applicants for project ${params.id}:`, error);

--- a/app/api/projects/[id]/route.ts
+++ b/app/api/projects/[id]/route.ts
@@ -23,7 +23,9 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
         { status: 400 }
       );
 
-    const project = await getProjectById(projectId);
+    // 인증된 owner에게만 임베드된 applicants에 PII(email, introduction) 포함
+    const isOwner = await verifyProjectPermission(projectId, request);
+    const project = await getProjectById(projectId, isOwner);
     if (!project) {
       return NextResponse.json({ error: "Project not found" }, { status: 404 });
     }

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -1,7 +1,30 @@
 import { getCurrentKoreanDate } from "@/lib/utils";
 import { ApplicantStatus, Project, ProjectStatus } from "@prisma/client";
 
+// projectAdminSelection / projectPublicSelection 모두 passwordHash를 제외하고
+// 반환하므로, 이메일 템플릿은 그 narrowed shape을 받을 수 있어야 한다.
+// 두 select 모두 admin/public이 사용하는 필드 superset을 포함한다.
+type ProjectForEmail = Omit<Project, "passwordHash">;
+
 const VERCEL_URL = process.env.VERCEL_URL || "http://localhost:3000";
+
+// 사용자 입력을 이메일 HTML 본문에 안전하게 보간하기 위한 HTML 이스케이프.
+// 미인증 라우트(POST /api/projects, /apply 등)에서 흘러들어온 사용자 입력이
+// 관리자/프로젝트 소유자 메일함에 그대로 렌더되는 것을 막는다.
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// Subject는 메일 헤더라, 개행 문자가 끼면 RFC 5322 header injection이
+// 가능해진다. CR/LF를 공백으로 치환.
+function escapeHeader(s: string): string {
+  return s.replace(/[\r\n]+/g, " ");
+}
 
 type EmailTemplate = {
   subject: string;
@@ -35,7 +58,7 @@ const applicantStatusAsVerboseKorean = (status: ApplicantStatus) => {
 /**
  * 새로운 프로젝트가 생성되었을 때 알림
  */
-const newProjectCreated = (newProject: Project): EmailTemplate => {
+const newProjectCreated = (newProject: ProjectForEmail): EmailTemplate => {
   const {
     id,
     name,
@@ -53,19 +76,19 @@ const newProjectCreated = (newProject: Project): EmailTemplate => {
   const link = `${VERCEL_URL}/projects/${id}`;
 
   return {
-    subject: `신규 프로젝트 생성: ${name}`,
+    subject: escapeHeader(`신규 프로젝트 생성: ${name}`),
     html: `새로운 프로젝트가 생성되었습니다.<br><br>
-    - 키워드: ${keywords.join(", ")}<br>
-    - 제안자: ${proposerName} (${proposerType})${
-      proposerMajor ? `, ${proposerMajor}` : ""
+    - 키워드: ${keywords.map(escapeHtml).join(", ")}<br>
+    - 제안자: ${escapeHtml(proposerName)} (${proposerType})${
+      proposerMajor ? `, ${escapeHtml(proposerMajor)}` : ""
     }<br>
     - 생성일: ${now}<br>
     - 프로젝트 링크: <a href="${link}">${link}</a><br>
-    - 추진배경: ${background}<br>
-    - 실행방: ${method}<br>
-    - 목표: ${objective}<br>
-    - 기대효과: ${result}<br>
-    - 기타 전달사항: ${etc}
+    - 추진배경: ${escapeHtml(background)}<br>
+    - 실행방: ${escapeHtml(method)}<br>
+    - 목표: ${escapeHtml(objective)}<br>
+    - 기대효과: ${escapeHtml(result)}<br>
+    - 기타 전달사항: ${etc ? escapeHtml(etc) : ""}
     `,
   };
 };
@@ -74,15 +97,15 @@ const newProjectCreated = (newProject: Project): EmailTemplate => {
  * 신청자가 프로젝트에 지원했을 때 알림
  */
 const applicantApplied = (
-  project: Project,
+  project: ProjectForEmail,
   applicantName: string
 ): EmailTemplate => {
   const projectLink = `${VERCEL_URL}/projects/${project.id}`;
   const now = getCurrentKoreanDate();
 
   return {
-    subject: `프로젝트 지원 알림: ${project.name}`,
-    html: `지원자 ${applicantName}님이 프로젝트에 지원했습니다.<br><br>
+    subject: escapeHeader(`프로젝트 지원 알림: ${project.name}`),
+    html: `지원자 ${escapeHtml(applicantName)}님이 프로젝트에 지원했습니다.<br><br>
     - 프로젝트 링크: <a href="${projectLink}">${projectLink}</a><br>
     - 지원일: ${now}
     `,
@@ -93,7 +116,7 @@ const applicantApplied = (
  * 신청자의 신청 상태가 변경됐을 때 알림
  */
 const applicantStatusChanged = (
-  project: Project,
+  project: ProjectForEmail,
   applicantName: string,
   prev: ApplicantStatus,
   curr: ApplicantStatus
@@ -102,8 +125,8 @@ const applicantStatusChanged = (
   const now = getCurrentKoreanDate();
 
   return {
-    subject: `프로젝트 지원 상태 변경: ${project.name}`,
-    html: `지원자 ${applicantName}님의 지원 상태가 변경되었습니다.<br><br>
+    subject: escapeHeader(`프로젝트 지원 상태 변경: ${project.name}`),
+    html: `지원자 ${escapeHtml(applicantName)}님의 지원 상태가 변경되었습니다.<br><br>
     - 이전 상태: ${applicantStatusAsVerboseKorean(prev)}<br>
     - 현재 상태: ${applicantStatusAsVerboseKorean(curr)}<br>
     - 프로젝트 링크: <a href="${projectLink}">${projectLink}</a><br>
@@ -116,7 +139,7 @@ const applicantStatusChanged = (
  * 프로젝트 상태 변경 알림
  */
 const projectStatusChanged = (
-  project: Project,
+  project: ProjectForEmail,
   prev: ProjectStatus,
   curr: ProjectStatus | "DELETED"
 ) => {
@@ -124,8 +147,8 @@ const projectStatusChanged = (
   const now = getCurrentKoreanDate();
 
   return {
-    subject: `프로젝트 상태 변경: ${project.name}`,
-    html: `프로젝트 ${project.name}의 상태가 변경되었습니다.<br><br>
+    subject: escapeHeader(`프로젝트 상태 변경: ${project.name}`),
+    html: `프로젝트 ${escapeHtml(project.name)}의 상태가 변경되었습니다.<br><br>
     - 이전 상태: ${projectStatusAsVerboseKorean(prev)}<br>
     - 현재 상태: ${projectStatusAsVerboseKorean(curr)}<br>
     - 프로젝트 링크: <a href="${projectLink}">${projectLink}</a><br>

--- a/services/applicant.ts
+++ b/services/applicant.ts
@@ -8,18 +8,20 @@ import {
 } from "@/lib/errors";
 import { prisma } from "@/lib/prisma";
 import {
+  ApplicantAdmin,
+  applicantAdminSelection,
   ApplicantInput,
+  ApplicantPublic,
   applicantPublicSelection,
   ApplicantUpdateInput,
 } from "@/types/applicant";
 import { ApplicantForProject, projectPublicSelection } from "@/types/project";
-import { Applicant } from "@prisma/client";
 import { waitUntil } from "@vercel/functions"; // Vercel 백그라운드 작업 유지를 위해 추가됨
 
 export async function applyToProject(
   projectId: number,
   data: ApplicantInput
-): Promise<Applicant> {
+): Promise<ApplicantPublic> {
   const project = await prisma.project.findUnique({
     where: { id: projectId },
     select: projectPublicSelection,
@@ -69,36 +71,48 @@ export async function applyToProject(
   return createdApplicant;
 }
 
+// isOwner=true(verifyProjectPermission 통과)일 때만 PII 포함된 admin select.
+// 미인증/비-owner 호출은 PII 제외된 public select.
 export async function getApplicantsByProjectId(
-  projectId: number
-): Promise<Applicant[]> {
-  const applicants = await prisma.applicant.findMany({
+  projectId: number,
+  isOwner: boolean = false
+): Promise<ApplicantPublic[] | ApplicantAdmin[]> {
+  if (isOwner) {
+    return await prisma.applicant.findMany({
+      where: { projectId },
+      select: applicantAdminSelection,
+      orderBy: { createdDatetime: "asc" },
+    });
+  }
+  return await prisma.applicant.findMany({
     where: { projectId },
     select: applicantPublicSelection,
     orderBy: { createdDatetime: "asc" },
   });
-  return applicants;
 }
 
 export async function getApplicantByIdForProject(
   applicantId: number,
-  projectId: number
-): Promise<Applicant | null> {
-  const applicant = await prisma.applicant.findUnique({
-    where: {
-      id: applicantId,
-      projectId: projectId,
-    },
+  projectId: number,
+  isOwner: boolean = false
+): Promise<ApplicantPublic | ApplicantAdmin | null> {
+  if (isOwner) {
+    return await prisma.applicant.findUnique({
+      where: { id: applicantId, projectId },
+      select: applicantAdminSelection,
+    });
+  }
+  return await prisma.applicant.findUnique({
+    where: { id: applicantId, projectId },
     select: applicantPublicSelection,
   });
-  return applicant;
 }
 
 export async function updateApplicant(
   applicantId: number,
   projectId: number,
   data: ApplicantUpdateInput
-): Promise<Applicant> {
+): Promise<ApplicantAdmin> {
   const applicantToUpdate = await prisma.applicant.findUnique({
     where: { id: applicantId, projectId },
   });
@@ -113,7 +127,7 @@ export async function updateApplicant(
       // projectId는 where 조건으로 이미 확인됨
     },
     data,
-    select: applicantPublicSelection,
+    select: applicantAdminSelection,
   });
   return updatedApplicant;
 }
@@ -121,7 +135,7 @@ export async function updateApplicant(
 export async function deleteApplicant(
   applicantId: number,
   projectId: number
-): Promise<Applicant> {
+): Promise<ApplicantAdmin> {
   const applicantToDelete = await prisma.applicant.findUnique({
     where: { id: applicantId, projectId },
   });
@@ -136,7 +150,7 @@ export async function deleteApplicant(
     where: {
       id: applicantId,
     },
-    select: applicantPublicSelection,
+    select: applicantAdminSelection,
   });
   return deletedApplicant;
 }
@@ -155,7 +169,7 @@ export async function acceptApplicant(
 
   const applicant = await prisma.applicant.findUnique({
     where: { id: applicantId },
-    select: applicantPublicSelection,
+    select: applicantAdminSelection,
   });
 
   if (!applicant || applicant.projectId !== projectId) {
@@ -192,7 +206,7 @@ export async function acceptApplicant(
   const updatedApplicant = await prisma.applicant.update({
     where: { id: applicantId },
     data: { status: "APPROVED" },
-    select: applicantPublicSelection,
+    select: applicantAdminSelection,
   });
 
   const applicantStatusChangedEmail = emailTemplates.applicantStatusChanged(
@@ -231,7 +245,7 @@ export async function rejectApplicant(
 
   const applicant = await prisma.applicant.findUnique({
     where: { id: applicantId },
-    select: applicantPublicSelection,
+    select: applicantAdminSelection,
   });
 
   if (!applicant || applicant.projectId !== projectId) {
@@ -247,7 +261,7 @@ export async function rejectApplicant(
   const updatedApplicant = await prisma.applicant.update({
     where: { id: applicantId },
     data: { status: "REJECTED" },
-    select: applicantPublicSelection,
+    select: applicantAdminSelection,
   });
 
   const applicantStatusChangedEmail = emailTemplates.applicantStatusChanged(
@@ -286,7 +300,7 @@ export async function pendingApplicant(
 
   const applicant = await prisma.applicant.findUnique({
     where: { id: applicantId },
-    select: applicantPublicSelection,
+    select: applicantAdminSelection,
   });
 
   if (!applicant || applicant.projectId !== projectId) {
@@ -302,7 +316,7 @@ export async function pendingApplicant(
   const updatedApplicant = await prisma.applicant.update({
     where: { id: applicantId },
     data: { status: "PENDING" },
-    select: applicantPublicSelection,
+    select: applicantAdminSelection,
   });
 
   const applicantStatusChangedEmail = emailTemplates.applicantStatusChanged(

--- a/services/project.ts
+++ b/services/project.ts
@@ -6,6 +6,7 @@ import { ProjectPasswordManager } from "@/lib/projectPasswordManager";
 import {
   ApplicantForProject,
   GetProjectsQueryInput,
+  projectAdminSelection,
   ProjectInput,
   projectPublicSelection,
   ProjectUpdateInput,
@@ -70,7 +71,7 @@ export async function verifyProjectPermission(
   }
 }
 
-export async function createProject(data: ProjectInput): Promise<Project> {
+export async function createProject(data: ProjectInput): Promise<PasswordOmittedProject> {
   const { password: projectPlainTextPassword, ...projectDataRest } = data;
 
   const projectPasswordHash = await bcrypt.hash(
@@ -243,10 +244,16 @@ export async function getAllProjects(
   };
 }
 
-export async function getProjectById(id: number): Promise<ProjectWithForeignKeys | null> {
+// isOwner=true(verifyProjectPermission 통과)일 때만 임베드된 applicants에
+// PII(email, introduction)를 포함한다. 미인증 호출은 PII 제외.
+export async function getProjectById(
+  id: number,
+  isOwner: boolean = false
+): Promise<ProjectWithForeignKeys | null> {
+  const select = isOwner ? projectAdminSelection : projectPublicSelection;
   const project = await prisma.project.findUnique({
     where: { id },
-    select: projectPublicSelection,
+    select,
   });
 
   if (project) {
@@ -270,7 +277,7 @@ export async function getProjectById(id: number): Promise<ProjectWithForeignKeys
 export async function updateProject(
   id: number,
   data: Omit<ProjectUpdateInput, "currentPassword">
-): Promise<Project> {
+): Promise<PasswordOmittedProject> {
   const { password: newPlainTextPassword, ...projectDataRest } = data;
   const projectToUpdate = await prisma.project.findUnique({ where: { id } });
 
@@ -287,7 +294,7 @@ export async function updateProject(
       ...projectDataRest,
       ...(projectPasswordHashToUpdate && { passwordHash: projectPasswordHashToUpdate }),
     },
-    select: projectPublicSelection,
+    select: projectAdminSelection,
   });
 }
 
@@ -323,7 +330,7 @@ export async function deleteProject(id: number): Promise<void> {
   }
 }
 
-export async function reopenProject(id: number): Promise<Project> {
+export async function reopenProject(id: number): Promise<PasswordOmittedProject> {
   const projectToReopen = await prisma.project.findUnique({
     where: { id },
     include: { applicants: true }
@@ -334,7 +341,7 @@ export async function reopenProject(id: number): Promise<Project> {
   const reopenedProject = await prisma.project.update({
     where: { id },
     data: { status: "RECRUITING" },
-    select: projectPublicSelection,
+    select: projectAdminSelection,
   });
 
   const projectStatusChangedEmail = emailTemplates.projectStatusChanged(
@@ -352,7 +359,7 @@ export async function reopenProject(id: number): Promise<Project> {
   return reopenedProject;
 }
 
-export async function closeProject(id: number): Promise<Project> {
+export async function closeProject(id: number): Promise<PasswordOmittedProject> {
   const projectToClose = await prisma.project.findUnique({
     where: { id },
     include: { applicants: true }
@@ -363,7 +370,7 @@ export async function closeProject(id: number): Promise<Project> {
   const closedProject = await prisma.project.update({
     where: { id },
     data: { status: "CLOSED" },
-    select: projectPublicSelection,
+    select: projectAdminSelection,
   });
 
   const projectStatusChangedEmail = emailTemplates.projectStatusChanged(

--- a/types/applicant.ts
+++ b/types/applicant.ts
@@ -14,14 +14,37 @@ export const ApplicantUpdateSchema = ApplicantSchema;
 export type ApplicantInput = z.infer<typeof ApplicantSchema>;
 export type ApplicantUpdateInput = z.infer<typeof ApplicantUpdateSchema>;
 
-export const applicantPublicSelection: Prisma.ApplicantSelect = {
+// Owner/admin 전용 — PII(email, introduction) 포함.
+// verifyProjectPermission 통과한 호출자에게만 사용.
+export const applicantAdminSelection = {
   id: true,
   name: true,
   email: true,
   major: true,
   introduction: true,
   status: true,
-  projectId: true, // 어떤 프로젝트의 지원자인지 표시
+  projectId: true,
   createdDatetime: true,
   updatedDatetime: true,
-};
+} satisfies Prisma.ApplicantSelect;
+
+// 공개 — PII(email, introduction) 제외.
+// ApplicantRow는 mode !== null일 때만 Dialog를 열어 email/introduction을
+// 표시하므로, mode === null(미인증) 컨텍스트에서는 이 두 필드가 UI에 필요 없다.
+// 미인증 GET 응답은 이 select만 사용해야 한다.
+export const applicantPublicSelection = {
+  id: true,
+  name: true,
+  major: true,
+  status: true,
+  projectId: true,
+  createdDatetime: true,
+  updatedDatetime: true,
+} satisfies Prisma.ApplicantSelect;
+
+export type ApplicantPublic = Prisma.ApplicantGetPayload<{
+  select: typeof applicantPublicSelection;
+}>;
+export type ApplicantAdmin = Prisma.ApplicantGetPayload<{
+  select: typeof applicantAdminSelection;
+}>;

--- a/types/project.ts
+++ b/types/project.ts
@@ -47,7 +47,8 @@ export type GetProjectsQueryInput = z.infer<typeof GetProjectsQuerySchema>;
 
 export type ApplicantForProject = Omit<Applicant, "projectId" | "project">;
 
-export const projectPublicSelection: Prisma.ProjectSelect = {
+// 공통 — 프로젝트 자체의 스칼라 필드는 admin/public 동일
+const projectScalarSelection = {
   id: true,
   name: true,
   viewCount: true,
@@ -67,6 +68,12 @@ export const projectPublicSelection: Prisma.ProjectSelect = {
   chatLink: true,
   status: true,
   passwordHash: false, // 비밀번호 해시 제외
+} satisfies Prisma.ProjectSelect;
+
+// Owner/admin 전용 — 임베드된 applicants에 PII(email, introduction) 포함.
+// verifyProjectPermission 통과한 호출자에게만 사용.
+export const projectAdminSelection = {
+  ...projectScalarSelection,
   applicants: {
     select: {
       id: true,
@@ -79,4 +86,20 @@ export const projectPublicSelection: Prisma.ProjectSelect = {
       status: true,
     },
   },
-};
+} satisfies Prisma.ProjectSelect;
+
+// 공개 — 임베드된 applicants에서 PII(email, introduction) 제외.
+// 미인증 GET / 목록 조회는 이 select만 사용한다.
+export const projectPublicSelection = {
+  ...projectScalarSelection,
+  applicants: {
+    select: {
+      id: true,
+      name: true,
+      major: true,
+      createdDatetime: true,
+      updatedDatetime: true,
+      status: true,
+    },
+  },
+} satisfies Prisma.ProjectSelect;


### PR DESCRIPTION
## 요약

미인증 공격자가 악용 가능한 보안 취약점 **2건**을 함께 수정합니다.

- **Vuln 4 (HIGH)** — 지원자 PII(이메일·자기소개) 미인증 노출
- **Vuln 3 (MEDIUM)** — 이메일 HTML/Subject 인젝션

함께 진행 중: dead 컴포넌트 정리 PR — urp3-team-matching/web#81 (별도 PR, 본 PR과 파일 겹침 0).

---

## Vuln 4 — 지원자 PII 차단

### 문제

`projectPublicSelection`의 임베드된 `applicants.select`가 `email`·`introduction`을 포함해 — 미인증 GET 3개 엔드포인트가 모든 지원자의 PII를 그대로 흘리고 있었음:

- `GET /api/projects` (목록의 모든 프로젝트의 임베드된 지원자들)
- `GET /api/projects/[id]`
- `GET /api/projects/[id]/applicants`

### SSOT(UI) 매핑 검증

| 필드 | 공개 UI 표시 | 결론 |
|---|---|---|
| `id` | Row key, count 기반 | 공개 |
| `name` | `{name}({major})` row header (ApplicantRow) — mode 무관 항상 표시 | 공개 |
| `major` | 같은 row header + 잠재적 MajorGraph 부활 | 공개 |
| `status` | Accordion 그룹핑(APPROVED/PENDING/REJECTED) | 공개 |
| `email` | Dialog 내부 — `mode === null` 클릭이 `preventDefault`로 막힘 → owner만 열림 | **owner-only** |
| `introduction` | Dialog 내부 — owner만 열림 | **owner-only** |

### 수정

- `types/applicant.ts`: `applicantAdminSelection`(PII 포함) / `applicantPublicSelection`(제외)로 분리. `satisfies Prisma.ApplicantSelect`로 literal 타입 보존
- `types/project.ts`: `projectAdminSelection` / `projectPublicSelection` 분리 (임베드된 applicants.select의 PII 포함 여부만 다름)
- `services/applicant.ts`: `getApplicantsByProjectId(projectId, isOwner)`, `getApplicantByIdForProject(applicantId, projectId, isOwner)` 시그니처 변경. accept/reject/pendingApplicant는 admin select (applicant.email을 상태 변경 메일 발송에 사용)
- `services/project.ts`: `getProjectById(id, isOwner)` 시그니처 변경. `updateProject`/`closeProject`/`reopenProject`는 admin select (owner-authed 경로)
- GET route handlers ([app/api/projects/[id]/route.ts](app/api/projects/%5Bid%5D/route.ts), [.../applicants/route.ts](app/api/projects/%5Bid%5D/applicants/route.ts)): `verifyProjectPermission(projectId, request)`로 `isOwner` 계산해 서비스에 전달
- 목록 `GET /api/projects`는 항상 public select (다른 프로젝트들의 owner 체크는 비현실적)
- `lib/email/templates.ts`: select narrowing이 `Project`에서 `passwordHash`를 제외하므로 템플릿 시그니처를 `Omit<Project, "passwordHash">`로 조정

`★ 결정` — 데이터 레이어(Prisma select)에서 minimum privilege을 강제. 미인증 요청은 DB에서 PII 컬럼을 *물리적으로* 가져오지 않음. 코드 어딘가에서 실수해도(로그 등) PII가 없으니 leak 불가.

---

## Vuln 3 — 이메일 HTML/Subject 인젝션

### 문제

`lib/email/templates.ts`의 4개 템플릿이 사용자 입력을 unsanitized로 보간:
- `newProjectCreated`: `background`/`method`/`objective`/`result`/`etc`/`keywords`/`proposerName`/`proposerMajor` + subject의 `name`
- `applicantApplied`: `applicantName` + subject의 `project.name`
- `applicantStatusChanged`: `applicantName` + subject의 `project.name`
- `projectStatusChanged`: `project.name` (subject + body)

미인증 라우트(`POST /api/projects`, `POST /api/projects/[id]/apply`)에서 도달 → 관리자/소유자 메일함에 임의 HTML(피싱 링크·콘텐츠 스푸핑) 주입 가능.

### 수정

- `escapeHtml(s)` — 5-char 표준(`& < > " '`) 치환. 모든 사용자 입력 보간 지점에 적용
- `escapeHeader(s)` — subject에서 CR/LF 제거 (RFC 5322 header injection 방지)
- `keywords`는 join 전에 각 요소를 escape (`keywords.map(escapeHtml).join(", ")`)
- `etc`는 nullable이라 `etc ? escapeHtml(etc) : ""` (원래의 `"null"` 문자열 렌더 부산물도 함께 해소)

---

## 검증

- `tsc --noEmit`: **0 errors** (수정 파일 + 전체)
- `eslint`: 수정 파일 0 warnings. `services/project.ts`에 3건 사전 존재 경고(`(applicant: any)` × 2, `_ unused`) — 본 PR이 안 건드린 라인, urp3-team-matching/web#81 또는 별도 PR 대상
- **E2E (로컬 Docker Postgres)**:
  - 익명 `GET /api/projects/1` → `applicants[].email`/`introduction` 부재 ✓
  - Owner(verified password cookie) `GET /api/projects/1` → 부재 안 함 ✓
  - 익명 `GET /api/projects/1/applicants` → PII 부재 ✓
  - Owner `GET /api/projects/1/applicants` → PII 존재 ✓
- Vuln 3은 escapeHtml/escapeHeader가 표준 함수 + diff에서 적용 위치 enumerate 가능 + tsc 통과로 코드 리뷰 검증

---

## 테스트 플랜

- [x] 익명 `GET /api/projects/[id]` 응답의 `applicants`에 `email`/`introduction` 없음
- [x] Owner 쿠키로 같은 요청 → 둘 다 포함됨
- [x] 익명 `GET /api/projects/[id]/applicants` 응답에 PII 없음
- [x] Owner로 같은 요청 → PII 포함됨
- [ ] 프로덕션 SMTP 환경에서 악성 입력으로 신청 → 받은 이메일에서 HTML이 텍스트로 표시됨(렌더 안 됨) 확인 *(SMTP 환경 필요, 로컬에서는 검증 못 함)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
