### PR TITLE
chore: add project-scoped MCP config (supabase + vercel)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "supabase": {
+      "type": "http",
+      "url": "https://mcp.supabase.com/mcp?project_ref=obawzgmgtoqegrrpbzml"
+    },
+    "vercel": {
+      "type": "http",
+      "url": "https://mcp.vercel.com/upr3team/web"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- 프로젝트 스코프 `.mcp.json` 신규 추가 — 팀이 공유하는 MCP 서버 SSOT
- `supabase` (기존 로컬 설정에만 있던 것), `vercel` (`https://mcp.vercel.com/upr3team/web`) 등록
- 토큰/시크릿 없음: 두 서버 모두 HTTP transport + OAuth 인증 (각자 첫 호출 시 브라우저 승인)

## Test plan
- [ ] PR 머지 후 `claude` (Claude Code) 재시작 → MCP 서버 승인 프롬프트 수락
- [ ] Vercel MCP 첫 호출(`list_projects` 등)에서 OAuth 정상 동작 확인
- [ ] `upr3team/web` slug가 실제 Vercel 프로젝트와 일치하는지 확인 (불일치 시 후속 PR로 수정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)