### PR TITLE
feat(theme): SKKU 브랜드 정체성 적용 (컬러 + Pretendard)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -39,54 +39,21 @@
   ::file-selector-button {
     border-color: var(--color-gray-200, currentColor);
   }
-
-  :root {
-    --sidebar-background: 0 0% 98%;
-    --sidebar-foreground: 240 5.3% 26.1%;
-    --sidebar-primary: 240 5.9% 10%;
-    --sidebar-primary-foreground: 0 0% 98%;
-    --sidebar-accent: 240 4.8% 95.9%;
-    --sidebar-accent-foreground: 240 5.9% 10%;
-    --sidebar-border: 220 13% 91%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
-  }
-
-  .dark {
-    --sidebar-background: 240 5.9% 10%;
-    --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 224.3 76.3% 48%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 3.7% 15.9%;
-    --sidebar-accent-foreground: 240 4.8% 95.9%;
-    --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
-  }
 }
 
 @utility text-balance {
   text-wrap: balance;
 }
 
-@layer utilities {
-  :root {
-    --background: #ffffff;
-    --foreground: #171717;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --background: #0a0a0a;
-      --foreground: #ededed;
-    }
-  }
-
-  body {
-    color: var(--foreground);
-    background: var(--background);
-  }
-}
-
 :root {
+  /* SKKU Brand Identity --- Source: skku.edu/skku/about/symbol/symbol_01.do
+     공식 가이드는 인쇄 중심(Pantone/CMYK). 디지털 사용 시
+     의미와 사용 강도 권고는 docs/DESIGN.md 참고. */
+  --skku-blue: #072b61;       /* Pantone 541C  --- 리더십, 신뢰, 지성, 책임 */
+  --skku-green: #8dc63f;      /* Pantone 367C  --- 다시 시작되는 역사 */
+  --skku-orange: #ff6c0f;     /* Pantone 1585C --- 창조, 역동, 혁신 */
+  --skku-dark-green: #124633; /* Pantone 3435C --- 소통, 공유, 협력 */
+
   --font-noto-sans-kr: "Noto Sans KR", sans-serif;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
@@ -94,10 +61,10 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.3 0.1 259);
+  --primary: var(--skku-blue);
   --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.76 0.17 123);
-  --secondary-foreground: oklch(1 0 0);
+  --secondary: var(--skku-green);
+  --secondary-foreground: oklch(0.145 0 0); /* SKKU Green 위 대비를 위해 ink black */
   --third: oklch(0.27 0.1 147);
   --muted: oklch(0.97 0 0);
   --muted-foreground: oklch(0.556 0 0);
@@ -108,10 +75,10 @@
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-1: var(--skku-blue);
+  --chart-2: var(--skku-green);
+  --chart-3: var(--skku-orange);
+  --chart-4: var(--skku-dark-green);
   --chart-5: oklch(0.769 0.188 70.08);
   --radius: 0.625rem;
   --sidebar: oklch(0.985 0 0);
@@ -139,10 +106,12 @@ body {
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.145 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.985 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
+  /* Dark mode: SKKU Blue가 어두운 배경에 묻히지 않도록 명도만 ↑ (relative color).
+     hue/chroma는 brand 정체성 유지. */
+  --primary: oklch(from var(--skku-blue) 0.62 c h);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: var(--skku-green);
+  --secondary-foreground: oklch(0.145 0 0);
   --muted: oklch(0.269 0 0);
   --muted-foreground: oklch(0.708 0 0);
   --accent: oklch(0.269 0 0);
@@ -152,10 +121,10 @@ body {
   --border: oklch(0.269 0 0);
   --input: oklch(0.269 0 0);
   --ring: oklch(0.439 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-1: oklch(from var(--skku-blue) 0.62 c h);
+  --chart-2: var(--skku-green);
+  --chart-3: var(--skku-orange);
+  --chart-4: oklch(from var(--skku-dark-green) 0.55 c h);
   --chart-5: oklch(0.645 0.246 16.439);
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
@@ -208,20 +177,18 @@ body {
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+
+  /* SKKU raw utilities --- bg-skku-blue, text-skku-orange 등으로 직접 사용 가능.
+     UI 전반엔 semantic 토큰(primary/secondary/...)을 우선 사용. */
+  --color-skku-blue: var(--skku-blue);
+  --color-skku-green: var(--skku-green);
+  --color-skku-orange: var(--skku-orange);
+  --color-skku-dark-green: var(--skku-dark-green);
 }
 
 /*
   ---break---
 */
-
-@layer base {
-  * {
-    @apply border-border outline-none;
-  }
-  body {
-    @apply bg-background text-foreground;
-  }
-}
 
 @layer base {
   * {

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css";
 
 @custom-variant dark (&:is(.dark *));
 
@@ -8,6 +9,14 @@
   --color-third: var(--third);
 
   --container-max-width: 1280px;
+
+  /* SKKU 지정서체(윤고딕/Frutiger)는 유료 라이선스. 공식 가이드의
+     "매체 특성에 따라 다른 서체 사용도 가능" 조항에 따라 Pretendard로 대체.
+     Pretendard는 한국 IT 사실상 표준 (Toss/Naver 채택, OFL 라이선스).
+     Source: skku.edu/skku/about/symbol/symbol_03.do */
+  --font-sans: "Pretendard Variable", "Pretendard", -apple-system,
+    BlinkMacSystemFont, ui-sans-serif, system-ui, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
 }
 
 .container {
@@ -54,7 +63,6 @@
   --skku-orange: #ff6c0f;     /* Pantone 1585C --- 창조, 역동, 혁신 */
   --skku-dark-green: #124633; /* Pantone 3435C --- 소통, 공유, 협력 */
 
-  --font-noto-sans-kr: "Noto Sans KR", sans-serif;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -90,14 +98,6 @@
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
 }
-
-body {
-  font-family: var(--font-noto-sans-kr); /* 설정된 폰트 변수 사용 */
-}
-
-/*
-  ---break---
-*/
 
 .dark {
   --background: oklch(0.145 0 0);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,19 +2,11 @@ import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import { AppSidebar } from "@/components/Header/AppSidebar";
 import { SidebarProvider } from "@/components/ui/sidebar";
-import { cn } from "@/lib/utils";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata } from "next";
-import { Noto_Sans_KR } from "next/font/google";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import "./globals.css";
-
-const notoSansKR = Noto_Sans_KR({
-  variable: "--font-noto-sans-kr",
-  subsets: ["latin"],
-  display: "swap",
-});
 
 export const metadata: Metadata = {
   title: "융합연구학점제 팀 모집 플랫폼",
@@ -33,7 +25,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <body className={cn(notoSansKR.className, "flex flex-col items-center")}>
+      <body className="flex flex-col items-center">
         <NuqsAdapter>
           <SidebarProvider>
             {/* ✅ 전체를 세로 레이아웃으로: (상단/본문/푸터) */}

--- a/components/Home/ProjectCard.tsx
+++ b/components/Home/ProjectCard.tsx
@@ -69,7 +69,10 @@ export default function ProjectCard({ project, className }: ProjectCardProps) {
       </div>
 
       {/* 신청 현황 */}
-      <Badge className="bg-green-400 text-white font-black flex flex-col *:text-xs gap-0 lg:text-base absolute w-14 h-10 lg:w-16 lg:h-12 top-1/2 -translate-y-1/2 right-0">
+      <Badge
+        variant="secondary"
+        className="font-black flex flex-col *:text-xs gap-0 lg:text-base absolute w-14 h-10 lg:w-16 lg:h-12 top-1/2 -translate-y-1/2 right-0"
+      >
         <span>지원현황</span>
         {applicantCount} / {MAX_APPLICANTS}
       </Badge>

--- a/components/Home/ProjectSort.tsx
+++ b/components/Home/ProjectSort.tsx
@@ -48,7 +48,8 @@ const ProjectSort = () => {
       <div className="flex gap-2 items-center">
         <Button
           asChild
-          className="hidden sm:flex w-full h-10 sm:w-50 sm:h-full bg-green-400 hover:bg-green-500 hover:cursor-pointer"
+          variant="secondary"
+          className="hidden sm:flex w-full h-10 sm:w-50 sm:h-full hover:cursor-pointer"
         >
           <Link href="/projects/create">
             <PencilIcon size={24} />
@@ -58,7 +59,8 @@ const ProjectSort = () => {
         {user && (
           <Button
             asChild
-            className="w-32 h-10 hidden sm:flex sm:w-50 sm:h-full bg-green-400 hover:bg-green-500 hover:cursor-pointer"
+            variant="secondary"
+            className="w-32 h-10 hidden sm:flex sm:w-50 sm:h-full hover:cursor-pointer"
           >
             <Link href="/posts/create">
               <PencilIcon size={24} />

--- a/components/Home/SearchRow.tsx
+++ b/components/Home/SearchRow.tsx
@@ -43,7 +43,8 @@ export default function SearchRow({ className }: SearchBarProps) {
       >
         <Button
           asChild
-          className="w-full h-10 sm:hidden sm:w-50 sm:h-full bg-green-400 hover:bg-green-500 hover:cursor-pointer"
+          variant="secondary"
+          className="w-full h-10 sm:hidden sm:w-50 sm:h-full hover:cursor-pointer"
         >
           <Link href="/projects/create">
             <PencilIcon size={24} />

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "next": "14.2.35",
     "nodemailer": "^7.0.5",
     "nuqs": "^2.4.3",
+    "pretendard": "^1.3.9",
     "react": "^18",
     "react-dom": "^18",
     "react-dropzone": "^14.3.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       nuqs:
         specifier: ^2.4.3
         version: 2.4.3(next@14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      pretendard:
+        specifier: ^1.3.9
+        version: 1.3.9
       react:
         specifier: ^18
         version: 18.3.1
@@ -2368,6 +2371,9 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  pretendard@1.3.9:
+    resolution: {integrity: sha512-PaQAADyLY5v4kYFwkpSJHbSSYIkiriY/1xXw75TKoZ9UQQqeU+tvP05yTdZAWibiIYoo8ZKtRv8PM7w0IaywSw==}
 
   prisma@6.12.0:
     resolution: {integrity: sha512-pmV7NEqQej9WjizN6RSNIwf7Y+jeh9mY1JEX2WjGxJi4YZWexClhde1yz/FuvAM+cTwzchcMytu2m4I6wPkIzg==}
@@ -5125,6 +5131,8 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  pretendard@1.3.9: {}
 
   prisma@6.12.0(typescript@5.8.3):
     dependencies:


### PR DESCRIPTION
## Summary

SKKU 공식 브랜드 정체성을 디자인 시스템에 반영합니다.
1. SKKU 4컬러를 shadcn semantic token에 매핑 + globals.css 청소
2. Pretendard 폰트로 표준화
3. 홈 화면 hardcoded `bg-green-400`을 semantic `secondary` variant로 교체

## 의사결정

### 컬러 매핑 (B: 균형)

| 토큰 | 매핑 | 화면 적용 |
|---|---|---|
| `--primary` | SKKU Blue #072B61 | "제출" 같은 결정적 CTA |
| `--secondary` | SKKU Green #8DC63F | "글쓰기"/"공지사항 추가"/"지원현황" 같은 보조 액션 |
| `--chart-1~4` | SKKU 4컬러 팔레트 | 데이터 시각화 |
| `--destructive` | 기본 빨강 유지 | SKKU Orange와 혼동 방지 |
| `--accent`, `--muted` | shadcn 기본 유지 | hover/비활성 |

**왜 절제 매핑인가**: skku.edu 본 사이트 자체가 흰 배경 + 회색 텍스트 + 파란 링크로 컬러를 절제. 모든 곳에 SKKU Blue를 칠하면 오히려 SKKU 톤과 멀어짐.

**Orange 처리**: WCAG AA 텍스트 대비 미달 (~2.7:1)이라 텍스트 컬러로 쓰지 않음. 필요 시 `bg-skku-orange` raw 유틸리티로 강조 배경에만 사용.

### Pretendard 폰트

SKKU 지정서체(윤고딕/Frutiger)는 유료 라이선스. 공식 가이드의 *"매체 특성에 따라 다른 서체 사용도 가능"* 조항([symbol_03.do](https://www.skku.edu/skku/about/symbol/symbol_03.do))에 따라 Pretendard로 대체. 한국 IT 사실상 표준(Toss/Naver 채택, OFL 라이선스).

### Hardcoded 컬러 정리 (d7d6e3e)

[components/Home/SearchRow.tsx](components/Home/SearchRow.tsx), [components/Home/ProjectSort.tsx](components/Home/ProjectSort.tsx), [components/Home/ProjectCard.tsx](components/Home/ProjectCard.tsx)의 `bg-green-400 hover:bg-green-500 text-white`가 SKKU 디자인 시스템을 우회하고 있었음. shadcn `variant="secondary"`로 교체해 `--secondary` 토큰을 통과시키도록 정합. 향후 매핑을 바꾸면 자동 반영됨.

부가 효과: contrast 개선 (Tailwind green-400 + white text = 2.04:1 AA fail → SKKU Green + ink black = 10.3:1 AAA pass).

## 시각 검증

홈/로그인/공지 작성 페이지에서 SKKU Blue/Green/Pretendard 적용 확인. OKLCH relative color 다크모드 처리도 Tailwind v4 turbo 빌드 통과.

## Test plan

- [ ] 로컬 `pnpm dev` 후 헤더/푸터/Button 컬러가 SKKU 톤인지 확인
- [ ] 한글 본문이 Pretendard로 렌더링되는지 (DevTools → computed font-family)
- [ ] 홈에서 글쓰기/지원현황이 SKKU Green인지 확인
- [ ] 차트 사용 페이지가 있다면 chart 컬러 확인

## 알려진 잔여 이슈 (별도 PR/이슈로 후속)

- **Hardcoded primitive 색상 전수 마이그레이션** → [#90](https://github.com/urp3-team-matching/web/issues/90) (글쓰기 추가 2건/차트/form error 등 Phase A~C 분류)

- 다크모드 활성화 — 현재 `.dark` 토큰은 정의돼 있으나 ThemeProvider 미도입. 토글 + contrast 미세조정 별도 PR
- [components/Home/SearchRow.tsx](components/Home/SearchRow.tsx) 검색 버튼의 `bg-third` 토큰 — 헤더 배너와 같은 비공식 진녹색. SKKU DarkGreen으로 정합할지 검토
- [components/Footer/index.tsx](components/Footer/index.tsx)의 `bg-[#343338]` 하드코딩 — 별도 토큰화 또는 muted 매핑 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)
