### PR TITLE
refactor(theme): hardcoded primitive 색상을 semantic 토큰으로 마이그레이션

### DIFF
--- a/app/error/page.tsx
+++ b/app/error/page.tsx
@@ -3,8 +3,8 @@
 export default function ErrorPage() {
   return (
     <div className="flex flex-col items-center justify-center my-10">
-      <h1 className="text-4xl font-bold text-red-600 mb-4">Error</h1>
-      <p className="text-lg text-gray-700">
+      <h1 className="text-4xl font-bold text-destructive mb-4">Error</h1>
+      <p className="text-lg text-muted-foreground">
         문제가 발생했습니다. 잠시 후 다시 시도해주세요.
       </p>
     </div>

--- a/app/posts/[id]/_components/PostForm.tsx
+++ b/app/posts/[id]/_components/PostForm.tsx
@@ -107,7 +107,7 @@ const PostForm = ({ postId }: { postId?: number }) => {
           <Label htmlFor="title">제목</Label>
           <Input {...register("title")} placeholder="제목" />
           {formState.errors.title && (
-            <p className="text-red-500">{formState.errors.title.message}</p>
+            <p className="text-destructive">{formState.errors.title.message}</p>
           )}
         </div>
 
@@ -118,7 +118,7 @@ const PostForm = ({ postId }: { postId?: number }) => {
             initialFiles={getValues("attachments")}
           />
           {formState.errors.attachments && (
-            <p className="text-red-500">
+            <p className="text-destructive">
               {formState.errors.attachments.message}
             </p>
           )}
@@ -128,7 +128,7 @@ const PostForm = ({ postId }: { postId?: number }) => {
           <Label htmlFor="content">본문</Label>
           <Textarea {...register("content")} placeholder="본문" />
           {formState.errors.content && (
-            <p className="text-red-500">{formState.errors.content.message}</p>
+            <p className="text-destructive">{formState.errors.content.message}</p>
           )}
         </div>
 

--- a/app/projects/[id]/_components/ApplyButton.tsx
+++ b/app/projects/[id]/_components/ApplyButton.tsx
@@ -98,11 +98,8 @@ const ProjectApplyButton = ({
       <DialogTrigger asChild>
         <Button
           disabled={!active}
-          variant="default"
-          className={cn(
-            `w-full h-[50px] hover:bg-green-400 bg-green-400`,
-            className
-          )}
+          variant="secondary"
+          className={cn("w-full h-[50px]", className)}
         >
           {active ? "신청하기" : "신청 마감"}
         </Button>

--- a/app/projects/[id]/_components/RightPanel/Chat/ChatBubble.tsx
+++ b/app/projects/[id]/_components/RightPanel/Chat/ChatBubble.tsx
@@ -18,7 +18,7 @@ const ChatBubble = forwardRef<HTMLDivElement, ChatBubbleProps>(
       : "items-start"; // 상대방 메시지 내용물 왼쪽 정렬
 
     const messageBubbleColor = chatGroup.isCurrentUser
-      ? "bg-sky-500 text-white" // 내 메시지 배경색
+      ? "bg-primary text-primary-foreground" // 내 메시지 배경색
       : "bg-gray-200 text-gray-800"; // 상대방 메시지 배경색
 
     const nameVisibility = chatGroup.isCurrentUser ? "hidden" : "visible"; // 내 이름은 숨김 (선택 사항)
@@ -53,7 +53,9 @@ const ChatBubble = forwardRef<HTMLDivElement, ChatBubbleProps>(
               {msg.text}
               <div
                 className={`text-xs mt-1 ${
-                  chatGroup.isCurrentUser ? "text-sky-200" : "text-gray-500"
+                  chatGroup.isCurrentUser
+                    ? "text-primary-foreground/70"
+                    : "text-gray-500"
                 } ${chatGroup.isCurrentUser ? "text-right" : "text-left"}`}
               >
                 {msg.time}

--- a/app/projects/[id]/_components/RightPanel/Chat/ChatField.tsx
+++ b/app/projects/[id]/_components/RightPanel/Chat/ChatField.tsx
@@ -356,7 +356,7 @@ export default function ChatField({ project }: ChatFieldProps) {
             <Textarea
               ref={textareaRef}
               name="text"
-              className="flex-grow resize-none text-sm text-gray-800 font-medium mr-2 py-2 px-3 border-gray-300 rounded-lg focus:ring-sky-500 focus:border-sky-500"
+              className="flex-grow resize-none text-sm text-gray-800 font-medium mr-2 py-2 px-3 border-gray-300 rounded-lg focus:ring-primary focus:border-primary"
               placeholder="프로젝트에 관심있는 학생들과 자유롭게 대화해보세요!"
               rows={1}
               onInput={handleTextareaInput}

--- a/app/projects/create/_components/RightPanel.tsx
+++ b/app/projects/create/_components/RightPanel.tsx
@@ -34,13 +34,14 @@ const ProjectCreateRightPanel = ({
       />
       <div className="flex justify-between gap-3">
         <Button
-          className="w-[30%] bg-slate-200 hover:bg-slate-300 text-black"
+          variant="outline"
+          className="w-[30%]"
           onClick={onCancel}
         >
           취소
         </Button>
         <Button
-          className="bg-green-400 w-[65%] hover:bg-green-500"
+          className="w-[65%]"
           onClick={onSubmit}
           disabled={loading}
         >

--- a/components/Project/Form/CancelAndSubmitButton.tsx
+++ b/components/Project/Form/CancelAndSubmitButton.tsx
@@ -35,14 +35,15 @@ const CancelAndSubmitButton = ({
       <Button
         onClick={onDelete}
         type="button"
-        className="text-white flex-1 cursor-pointer text-base font-normal  h-10 bg-red-400 hover:bg-red-300 rounded-lg"
+        variant="destructive"
+        className="flex-1 cursor-pointer text-base font-normal h-10 rounded-lg"
       >
         삭제
       </Button>
       <Button
         type="button"
         onClick={onToggleClose}
-        className="text-white flex-1 cursor-pointer text-base font-normal  h-10 bg-orange-400 hover:bg-orange-300 rounded-lg"
+        className="text-white flex-1 cursor-pointer text-base font-normal h-10 bg-skku-orange hover:bg-skku-orange/90 rounded-lg"
       >
         {isProjectClosed ? "재모집" : "모집마감"}
       </Button>


### PR DESCRIPTION
[Issue #90](https://github.com/urp3-team-matching/web/issues/90)의 Phase A + B를 한 PR로 처리. 코드베이스 전반의 hardcoded primitive 색상을 SKKU 디자인 시스템 토큰으로 정리.

## Summary

| Phase | 항목 | 처리 |
|---|---|---|
| A | RightPanel 등록/취소 | default(primary) / outline |
| A | ApplyButton 신청하기 | variant="secondary" |
| A | error/page 텍스트 | text-destructive / text-muted-foreground |
| A | PostForm form error 3건 | text-destructive |
| B | CancelAndSubmitButton 삭제 | variant="destructive" |
| B | CancelAndSubmitButton 모집마감 | bg-skku-orange (SKKU raw 토큰) |
| B | ChatBubble 내 메시지 | bg-primary text-primary-foreground |
| B | ChatField focus | focus:ring-primary focus:border-primary |

## 의사결정 근거

### Phase A — 명확한 매핑

- **RightPanel 등록 → primary(SKKU Blue)**: "결정적 CTA = primary" 정의([PR #84](https://github.com/urp3-team-matching/web/pull/84))와 정합. 시각적 위계도 명확 (취소 outline vs 등록 SKKU Blue)
- **ApplyButton 신청하기 → secondary(SKKU Green)**: 글쓰기/지원 패턴과 일관. SKKU Green이라 친근한 톤 유지
- **text-red-* → text-destructive**: 의미적 destructive token 활용 (4건)

### Phase B — 사용자 의도 결정 후

- **삭제 → destructive**: 빨강의 위험 의미 정합. shadcn destructive variant 활용
- **모집마감 → bg-skku-orange**: 경고성 토글의 'orange' 의도 유지하면서 SKKU 4컬러 안에서 매핑 (raw 토큰 활용)
- **채팅 → primary 통합**: SKKU 정체성 우선 (채팅 brand color 약화 트레이드오프 인정). iMessage 스타일 sky 톤 포기 대신 일관성

## 의도상 유지된 항목

- **Footer `bg-[#343338]`**: 단일 사용, 다크 surface 의도 명확. 토큰화 가치 낮아 유지
- **ProposalBadge `bg-indigo-800`/`bg-teal-800`**: proposer type(학생/호스트) 시각 구분이 의미적. SKKU 컬러로 매핑하면 의미 약해질 위험 있어 유지 (PROFESSOR는 이미 `bg-third` semantic)

## 시각 검증

프로젝트 생성 페이지에서 확인:
- 취소: outline (회색 테두리)
- 등록: SKKU Blue (primary)
시각적 위계 명확.

채팅/ApplyButton 페이지는 실데이터 필요 → Vercel preview에서 확인 권장.

## 후속 작업 (이 PR 범위 밖)

Issue #90 Phase C — gray-likes(`text-slate-500`, `bg-gray-100`, `hover:bg-slate-50` 등) 30+ 인스턴스의 `muted/card/accent` 마이그레이션. 거대 작업이라 별도 PR 시리즈 또는 보류.

🤖 Generated with [Claude Code](https://claude.com/claude-code)