### PR TITLE
fix(home): 모바일에서 키워드 태그 글자 단위 줄바꿈 방지

### DIFF
--- a/components/Badge/KeywordBadge.tsx
+++ b/components/Badge/KeywordBadge.tsx
@@ -1,6 +1,6 @@
 export default function KeywordBadge({ keyword }: { keyword: string }) {
   return (
-    <div className="h-5 px-2.5 text-xs sm:text-sm font-medium py-1 bg-gray-200 rounded-sm inline-flex justify-center items-center gap-2.5">
+    <div className="min-h-5 px-2.5 text-xs sm:text-sm font-medium py-1 bg-gray-200 rounded-sm inline-flex justify-center items-center gap-2.5 whitespace-nowrap">
       {`#` + keyword}
     </div>
   );

--- a/components/Home/ProjectCard.tsx
+++ b/components/Home/ProjectCard.tsx
@@ -57,7 +57,7 @@ export default function ProjectCard({ project, className }: ProjectCardProps) {
           {/*키워드*/}
           <div
             className={cn(
-              "flex gap-1 my-[2px]",
+              "flex flex-wrap gap-1 my-[2px]",
               !project.keywords.length && "hidden"
             )}
           >


### PR DESCRIPTION
## Summary

- `KeywordBadge`에 `whitespace-nowrap` 추가 — CJK 문자가 글자 단위로 쪼개지는 브라우저 기본 동작 차단
- `ProjectCard` 키워드 컨테이너에 `flex-wrap` 추가 — 배지가 카드 폭을 넘으면 다음 줄로 wrap
- `h-5` 고정 높이를 `min-h-5`로 완화

Closes [urp3-team-matching/web#95](https://github.com/urp3-team-matching/web/issues/95)

## Test plan

- [ ] 모바일(~390px)에서 홈 화면을 열어 키워드가 많은(4개+) 또는 긴(7자+) 프로젝트 카드 확인
- [ ] `#스마트팩토리` 등 한국어 키워드가 *글자 단위로 쪼개지지 않는지* 확인
- [ ] `#차량용 네트워크` 등 공백 포함 키워드도 한 배지 내부에서 줄바꿈 없는지 확인
- [ ] 키워드 합산 폭이 카드 폭을 초과할 때 배지 단위로 줄이 바뀌는지 확인
- [ ] 데스크톱 폭에서 기존 레이아웃에 회귀 없는지 확인