### PR TITLE
style(home): 지원현황 영역 시각 다듬기 (secondary white + font-black 해제)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -72,7 +72,7 @@
   --primary: var(--skku-blue);
   --primary-foreground: oklch(0.985 0 0);
   --secondary: var(--skku-green);
-  --secondary-foreground: oklch(0.145 0 0); /* SKKU Green 위 대비를 위해 ink black */
+  --secondary-foreground: oklch(1 0 0); /* SKKU Green 위 white — 브랜드 일관성 우선, 가독성보다 비주얼 */
   --third: oklch(0.27 0.1 147);
   --muted: oklch(0.97 0 0);
   --muted-foreground: oklch(0.556 0 0);
@@ -111,7 +111,7 @@
   --primary: oklch(from var(--skku-blue) 0.62 c h);
   --primary-foreground: oklch(0.985 0 0);
   --secondary: var(--skku-green);
-  --secondary-foreground: oklch(0.145 0 0);
+  --secondary-foreground: oklch(1 0 0);
   --muted: oklch(0.269 0 0);
   --muted-foreground: oklch(0.708 0 0);
   --accent: oklch(0.269 0 0);

--- a/components/Home/ProjectCard.tsx
+++ b/components/Home/ProjectCard.tsx
@@ -71,7 +71,7 @@ export default function ProjectCard({ project, className }: ProjectCardProps) {
       {/* 신청 현황 */}
       <Badge
         variant="secondary"
-        className="font-black flex flex-col *:text-xs gap-0 lg:text-base absolute w-14 h-10 lg:w-16 lg:h-12 top-1/2 -translate-y-1/2 right-0"
+        className="flex flex-col *:text-xs gap-0 lg:text-base absolute w-14 h-10 lg:w-16 lg:h-12 top-1/2 -translate-y-1/2 right-0"
       >
         <span>지원현황</span>
         {applicantCount} / {MAX_APPLICANTS}


### PR DESCRIPTION
## Summary

홈 화면 지원현황 영역을 중심으로 secondary 컴포넌트 시각을 다듬습니다.

### 1. `--secondary-foreground` 토큰 black → white

SKKU Green 배경 위 텍스트가 white일 때 브랜드 톤이 더 잘 어울림. `Button`/`Badge`의 `secondary` variant가 같은 토큰을 참조하므로 한 번에 적용됨.

### 2. 지원현황 배지의 `font-black` 제거

`font-black`(900)은 작은 배지에 과도. Badge 디폴트 `font-medium`(500)으로 fallback.

## 영향 받는 UI (secondary variant 사용처)

- 홈: 글쓰기 버튼 ([SearchRow](https://github.com/urp3-team-matching/web/blob/344a61c/components/Home/SearchRow.tsx#L46), [ProjectSort](https://github.com/urp3-team-matching/web/blob/344a61c/components/Home/ProjectSort.tsx#L51-L62))
- 홈: 지원현황 배지 ([ProjectCard](https://github.com/urp3-team-matching/web/blob/344a61c/components/Home/ProjectCard.tsx#L73)) — text white + bold 해제
- 로그인 버튼 ([login/page](https://github.com/urp3-team-matching/web/blob/344a61c/app/login/page.tsx#L17))
- 프로젝트 상세 지원하기 버튼 ([ApplyButton](https://github.com/urp3-team-matching/web/blob/344a61c/app/projects/%5Bid%5D/_components/ApplyButton.tsx#L101))
- 지원자 관리 / 채팅 영역 ([ApplicantRow](https://github.com/urp3-team-matching/web/blob/344a61c/app/projects/%5Bid%5D/_components/RightPanel/Chat/ApplicantsManage/ApplicantRow.tsx), [ChatField](https://github.com/urp3-team-matching/web/blob/344a61c/app/projects/%5Bid%5D/_components/RightPanel/Chat/ChatField.tsx#L414))

## 트레이드오프 (리뷰어 확인 부탁)

SKKU Green `#8dc63f` 위 텍스트 대비비:

| 색상 | 대비비 | WCAG |
|---|---|---|
| black (기존) | ~11.7:1 | AAA |
| white (변경) | ~1.8:1 | AA(4.5:1) **미달** |

가독성은 기존 black 우위. 이번 변경은 브랜드 일관성 / 비주얼 우선의 의식적 결정.

## Test plan

- [ ] 홈 화면(모바일/데스크탑)에서 글쓰기 버튼, 지원현황 배지 텍스트가 white + medium weight인지 확인
- [ ] 로그인 페이지의 secondary 버튼 텍스트 확인
- [ ] 프로젝트 상세 페이지 지원하기 버튼, 지원자 관리, 채팅 영역의 secondary 컴포넌트 확인
- [ ] 다크 모드(있다면) 회귀 확인