### PR TITLE
fix(seed): allow anon CRUD on web-development storage bucket

### DIFF
--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -6,6 +6,33 @@ insert into storage.buckets (id, name, public)
 values ('web-development', 'web-development', true)
 on conflict (id) do nothing;
 
+-- RLS policies for local dev bucket — allow anon CRUD on web-development.
+-- prisma/seed.ts uploads via anon key (NEXT_PUBLIC_SUPABASE_ANON_KEY); without
+-- these policies storage.objects RLS rejects with "new row violates RLS".
+-- Local-only: prod's web-production bucket should keep stricter policies
+-- (use service_role for admin uploads instead).
+drop policy if exists "anon insert web-development" on storage.objects;
+drop policy if exists "anon select web-development" on storage.objects;
+drop policy if exists "anon update web-development" on storage.objects;
+drop policy if exists "anon delete web-development" on storage.objects;
+
+create policy "anon insert web-development"
+  on storage.objects for insert to anon
+  with check (bucket_id = 'web-development');
+
+create policy "anon select web-development"
+  on storage.objects for select to anon
+  using (bucket_id = 'web-development');
+
+create policy "anon update web-development"
+  on storage.objects for update to anon
+  using (bucket_id = 'web-development')
+  with check (bucket_id = 'web-development');
+
+create policy "anon delete web-development"
+  on storage.objects for delete to anon
+  using (bucket_id = 'web-development');
+
 -- Local dev admin account. Email: admin@local.test / Password: dev1234
 -- /login uses supabase.auth.signInWithPassword (actions/auth.ts).
 do $$


### PR DESCRIPTION
## Summary

`supabase/seed.sql` 에 storage RLS policy 4개 (INSERT/SELECT/UPDATE/DELETE) 추가 → `prisma/seed.ts` 의 attachment 업로드가 anon key 로 통과.

Closes urp3-team-matching/web#91

## 변경

- `supabase/seed.sql` 에 anon CRUD policy on `web-development` bucket
- `drop policy if exists` 로 idempotent 보장

## 검증

- `pnpm dev:reset` 사이클 통과
- seed 실행 시 "파일 업로드 실패" 0건 (이전엔 14건 모두 RLS 차단)
- `select count(*) from storage.objects where bucket_id = 'web-development'` → **14** (이전 0)

## prod 영향 0

policy 가 `bucket_id = 'web-development'` 로 scope. prod 의 `web-production` bucket 은 영향 없음. prod 는 admin 작업 시 service_role 사용 권장 (별도 작업).