### PR TITLE
style(ProjectCard): 지원현황 Badge bold(font-black) 해제

### DIFF
--- a/components/Home/ProjectCard.tsx
+++ b/components/Home/ProjectCard.tsx
@@ -71,7 +71,7 @@ export default function ProjectCard({ project, className }: ProjectCardProps) {
       {/* 신청 현황 */}
       <Badge
         variant="secondary"
-        className="font-black flex flex-col *:text-xs gap-0 lg:text-base absolute w-14 h-10 lg:w-16 lg:h-12 top-1/2 -translate-y-1/2 right-0"
+        className="flex flex-col *:text-xs gap-0 lg:text-base absolute w-14 h-10 lg:w-16 lg:h-12 top-1/2 -translate-y-1/2 right-0"
       >
         <span>지원현황</span>
         {applicantCount} / {MAX_APPLICANTS}


### PR DESCRIPTION
## 요약

홈 프로젝트 카드의 "지원현황" Badge에 `font-black`(weight 900)이 들어가 있어 카드 내 다른 텍스트 대비 과하게 강조됨. Badge 기본 weight로 회복.

## 변경

`components/Home/ProjectCard.tsx`의 Badge `className`에서 `font-black ` 한 단어 제거. 다른 레이아웃 클래스(`flex flex-col *:text-xs gap-0 lg:text-base absolute ...`)는 그대로 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
