### PR TITLE
chore(types): add PROJECT_ENCRYPTION_KEY and ADMIN_EMAILS to env.d.ts

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -10,6 +10,9 @@ declare global {
 
       EMAIL_SERVER_USER: string;
       EMAIL_SERVER_PASSWORD: string;
+
+      PROJECT_ENCRYPTION_KEY: string;
+      ADMIN_EMAILS: string;
     }
   }
 }


### PR DESCRIPTION
## Summary

`env.d.ts`의 `ProcessEnv` 인터페이스에 `PROJECT_ENCRYPTION_KEY`와 `ADMIN_EMAILS` 추가.

두 env는 실제로 코드에서 사용 중이나 타입 선언에서 누락되어 있어, 오타 시 `undefined`가 조용히 흘러갈 위험이 있었음.

- `PROJECT_ENCRYPTION_KEY` → [lib/encryption.ts](lib/encryption.ts)
- `ADMIN_EMAILS` → [app/api/cron/keep-alive/route.ts](app/api/cron/keep-alive/route.ts)

Closes [urp3-team-matching/web#97](https://github.com/urp3-team-matching/web/issues/97)

## Verification

- `pnpm exec tsc --noEmit` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)