### PR TITLE
fix(chat): isolate Realtime channel per ChatField instance

### DIFF
--- a/app/projects/[id]/_components/RightPanel/Chat/ChatField.tsx
+++ b/app/projects/[id]/_components/RightPanel/Chat/ChatField.tsx
@@ -23,7 +23,7 @@ import type { RealtimePostgresInsertPayload } from "@supabase/supabase-js";
 
 import { getClientSupabase } from "@/utils/supabase/client";
 import { Send } from "lucide-react";
-import { KeyboardEvent, useEffect, useRef, useState } from "react";
+import { KeyboardEvent, useEffect, useId, useRef, useState } from "react";
 import ChatBubble from "./ChatBubble";
 
 const COOKIE_KEY = "chat_user_data";
@@ -132,6 +132,11 @@ export default function ChatField({ project }: ChatFieldProps) {
 
   const supabase = getClientSupabase();
 
+  // ChatField는 Desktop(RightPanel)과 Mobile(page.tsx 하단)에 동시에 마운트된다.
+  // supabase-js v2.106+는 같은 channel name 재호출 시 동일 인스턴스를 반환하고,
+  // 이미 subscribed인 채널에 .on()을 또 부르면 throw — 인스턴스별 suffix로 격리.
+  const instanceId = useId();
+
   function enterChatRoom(isAdmin: boolean, major: string, nickname: string) {
     let userId = "";
     if (!isAdmin) {
@@ -181,7 +186,7 @@ export default function ChatField({ project }: ChatFieldProps) {
     fetchInitialMessages();
 
     const channel = supabase
-      .channel(`project-chat-room-${projectId}`)
+      .channel(`project-chat-room-${projectId}-${instanceId}`)
       .on(
         "postgres_changes",
         {
@@ -208,7 +213,7 @@ export default function ChatField({ project }: ChatFieldProps) {
     return () => {
       supabase.removeChannel(channel).catch(console.error);
     };
-  }, [projectId, supabase]);
+  }, [projectId, supabase, instanceId]);
 
   useEffect(() => {
     setDisplayedChats(transformMessagesForDisplay(rawMessages, currentUserId));


### PR DESCRIPTION
## Summary

- **프로덕션 핫픽스**: 모든 `/projects/*` 및 `/` 페이지에서 클라이언트 사이드 throw 발생 — `Uncaught Error: cannot add postgres_changes callbacks for realtime:project-chat-room-{id} after subscribe()`. [#100](https://github.com/urp3-team-matching/web/pull/100) 의 `@supabase/supabase-js 2.49.8 → 2.106.1` 메이저 bump 직후부터.
- 원인: [page.tsx](https://github.com/urp3-team-matching/web/blob/f522964/app/projects/%5Bid%5D/page.tsx#L338-L343) 에서 `<Chat>` 이 **두 곳에 동시 마운트** — Desktop의 `<RightPanel>` 안 + Mobile의 `lg:hidden` div 하단. CSS 로 한쪽만 보일 뿐 React 트리에 둘 다 존재.
- 두 ChatField가 같은 channel name `project-chat-room-${projectId}` 로 `supabase.channel(...)` 호출 → supabase-js 2.106 은 동일 인스턴스 반환 → 두 번째 `.on('postgres_changes', ...)` 가 이미 `.subscribe()` 된 채널에 콜백을 더하려다 hard throw. ErrorBoundary 가 잡아서 \"This page couldn't load\" fallback.
- 이전 버전(2.49.8)에선 silent 통과했지만 2.106 부터 validation 강화.

## Fix

`useId()` 로 인스턴스별 unique suffix 를 channel name 에 붙임. 두 ChatField 가 독립 채널 구독 → 충돌 없음. 둘 다 같은 Message INSERT 이벤트를 각자 받음 (네트워크 약간 중복이지만 동작 정상).

## Test plan

- [ ] Vercel Preview 빌드 성공
- [ ] Preview `/projects/68` console error 0건 (현재 production은 throw)
- [ ] Preview 에서 메시지 송수신 정상 동작
- [ ] 머지 후 production `/projects/68` 정상 로드

## Follow-up (별도 PR)

근본 fix 는 \`page.tsx\` 에서 Chat 을 한 곳에서만 마운트하는 구조 변경. lg breakpoint conditional rendering 은 hydration mismatch 위험이 있어 hotfix 에선 회피.

🤖 Generated with [Claude Code](https://claude.com/claude-code)