### PR TITLE
fix(proxy): guard /posts/create with auth (matcher typo)

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -8,5 +8,5 @@ export async function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/posts/:id/create", "/posts/:id/edit"],
+  matcher: ["/posts/create", "/posts/:id/edit"],
 };


### PR DESCRIPTION
## Symptom

`proxy.ts` matcher 가 `/posts/:id/create` 로 박혀있는데 실제 route 는 `/posts/create` (no `[id]` segment). matcher 미스매치 → **`/posts/create` 가 비인증으로 누구나 접근 가능**.

```ts
// Before
matcher: ["/posts/:id/create", "/posts/:id/edit"]
//        ^^^^^^^^^^^^^^^^^^^^ dead — no such route

// After
matcher: ["/posts/create", "/posts/:id/edit"]
```

## 회귀 timeline

| commit | 날짜 | matcher |
|---|---|---|
| 03a08e1 admin 인증 추가 | (초기) | `[]` (match all, Supabase starter 표준) |
| **1476d1e** feat: 공지사항 + file upload hook | **2025-09-09** | `["/posts/:id/create", "/posts/:id/edit"]` ← typo 도입 |
| b68b384 Next 16 upgrade | (최근) | rename 만, matcher 그대로 |

→ 약 8.5 개월 동안 누구나 `/posts/create` 에서 글 작성 가능 상태.

## 검증 방법

PR Preview 또는 prod 머지 후:
1. 비로그인 상태로 `/posts/create` 접속 → `/login` 으로 redirect 되어야 OK
2. 로그인 후 `/posts/create` 접속 → 정상 로드

## 발견 맥락

urp3-team-matching/web#102 (prod storage anon write) 작업 중 route 인증 coverage 감사하다가 발견. 별도 PR 로 분리 (storage RLS 와 무관).
