### PR TITLE
feat(home): 프로젝트 목록 기본 정렬 최신순 + 상태 필터 모집중

### DIFF
--- a/components/Filter/index.tsx
+++ b/components/Filter/index.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import TabTrigger from "@/components/Filter/TabTrigger";
-import { GetProjectsQuerySchema } from "@/types/project";
+import {
+  GetProjectsQuerySchema,
+  STATUS_FILTER_ALL,
+  StatusFilter,
+  StatusFilterSchema,
+} from "@/types/project";
 import { parseAsInteger, parseAsStringEnum, useQueryState } from "nuqs";
 import { z } from "zod";
 
@@ -17,10 +22,17 @@ import {
 import { Semester } from "@/types/project";
 import { ProjectStatus } from "@prisma/client";
 
+const STATUS_FILTER_VALUES: StatusFilter[] = [
+  ...Object.values(ProjectStatus),
+  STATUS_FILTER_ALL,
+];
+
 const Filter = () => {
   const [filter, setFilter] = useQueryState(
     "status" as keyof z.infer<typeof GetProjectsQuerySchema>,
-    parseAsStringEnum<ProjectStatus>(Object.values(ProjectStatus))
+    parseAsStringEnum<StatusFilter>(STATUS_FILTER_VALUES).withDefault(
+      ProjectStatus.RECRUITING
+    )
   );
 
   const currentYear = new Date().getFullYear();
@@ -77,7 +89,10 @@ const Filter = () => {
       {/* 필터 대상: 상태 */}
       {/* PC : TAP 방식 */}
       <div className="flex-1 max-sm:hidden h-10 *:cursor-pointer items-center border-b-[1px] *:border-black border-b-black flex">
-        <TabTrigger active={filter === null} onClick={() => setFilter(null)}>
+        <TabTrigger
+          active={filter === STATUS_FILTER_ALL}
+          onClick={() => setFilter(STATUS_FILTER_ALL)}
+        >
           전체
         </TabTrigger>
 
@@ -100,17 +115,17 @@ const Filter = () => {
       <div className="min-sm:hidden flex gap-x-1">
         <Label htmlFor="status">상태</Label>
         <Select
-          value={filter ?? "all"} // null이면 all로 보여줌
+          value={filter}
           onValueChange={(value) => {
-            if (value === "all") setFilter(null);
-            else setFilter(value as ProjectStatus);
+            const parsed = StatusFilterSchema.safeParse(value);
+            if (parsed.success) setFilter(parsed.data);
           }}
         >
           <SelectTrigger className="w-[110px]">
-            <SelectValue placeholder="전체" />
+            <SelectValue placeholder="모집중" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">전체</SelectItem>
+            <SelectItem value={STATUS_FILTER_ALL}>전체</SelectItem>
             <SelectItem value={ProjectStatus.RECRUITING}>모집중</SelectItem>
             <SelectItem value={ProjectStatus.CLOSED}>모집마감</SelectItem>
           </SelectContent>

--- a/components/Home/ProjectSort.tsx
+++ b/components/Home/ProjectSort.tsx
@@ -19,7 +19,7 @@ const ProjectSort = () => {
 
   const [sort, setSort] = useQueryState(
     "sortBy" as keyof z.infer<typeof GetProjectsQuerySchema>,
-    parseAsStringEnum<Sort>(Object.values(Sort))
+    parseAsStringEnum<Sort>(Object.values(Sort)).withDefault(Sort.LATEST)
   );
 
   return (

--- a/components/Pagination/index.tsx
+++ b/components/Pagination/index.tsx
@@ -30,7 +30,7 @@ const CustomPagination = ({
 }: CustomPaginationProps) => {
   const [page, setPage] = useQueryState(
     queryKey,
-    parseAsInteger.withDefault(0)
+    parseAsInteger.withDefault(1)
   );
 
   const maxPagesToShow = 5; // 표시할 최대 페이지 수
@@ -69,10 +69,7 @@ const CustomPagination = ({
 
   const isFirstPage = page === 1;
   const isLastPage = page === totalPages;
-  const isCurrentOrDefaultPage = (pageNumber: number | string) => {
-    if (page === 0 && pageNumber === 1) return true;
-    return pageNumber === page;
-  };
+  const isCurrentPage = (pageNumber: number | string) => pageNumber === page;
 
   if (totalPages <= 1) {
     return null;
@@ -118,11 +115,11 @@ const CustomPagination = ({
               <PaginationLink
                 onClick={() => setPage(Number(pageNumber))}
                 className={cn(
-                  isCurrentOrDefaultPage(pageNumber) &&
+                  isCurrentPage(pageNumber) &&
                     "bg-secondary text-white hover:bg-secondary hover:text-white"
                 )}
                 aria-label={`Go to page ${pageNumber}`}
-                isActive={isCurrentOrDefaultPage(pageNumber)}
+                isActive={isCurrentPage(pageNumber)}
               >
                 {pageNumber}
               </PaginationLink>

--- a/services/project.ts
+++ b/services/project.ts
@@ -11,6 +11,7 @@ import {
   projectPublicSelection,
   ProjectUpdateInput,
   Semester,
+  STATUS_FILTER_ALL,
 } from "@/types/project";
 import { PaginatedType, PasswordOmittedType } from "@/types/utils";
 import { getServerSupabase } from "@/utils/supabase/server";
@@ -224,7 +225,7 @@ export async function getAllProjects(
   let filteredProjects: PasswordOmittedProject[] = projectsFromDb as PasswordOmittedProject[];
   let finalTotalCount = totalCount;
 
-  if (status) {
+  if (status && status !== STATUS_FILTER_ALL) {
     const allProjects = await prisma.project.findMany({
       where: whereConditions,
       select: projectPublicSelection,

--- a/services/project.ts
+++ b/services/project.ts
@@ -160,6 +160,7 @@ export async function getAllProjects(
   if (name) whereConditions.name = { contains: name, mode: "insensitive" };
   if (keyword) whereConditions.keywords = { has: keyword };
   if (proposerType) whereConditions.proposerType = proposerType;
+  if (status && status !== STATUS_FILTER_ALL) whereConditions.status = status;
   if (searchTerm) {
     whereConditions.OR = [
       { name: { contains: searchTerm, mode: "insensitive" } },
@@ -222,24 +223,10 @@ export async function getAllProjects(
     take: take,
   });
 
-  let filteredProjects: PasswordOmittedProject[] = projectsFromDb as PasswordOmittedProject[];
-  let finalTotalCount = totalCount;
-
-  if (status && status !== STATUS_FILTER_ALL) {
-    const allProjects = await prisma.project.findMany({
-      where: whereConditions,
-      select: projectPublicSelection,
-    });
-
-    const filteredAllProjects = allProjects.filter((project) => project.status === status);
-    finalTotalCount = filteredAllProjects.length;
-    filteredProjects = filteredAllProjects.slice(skip, skip + take);
-  }
-
   return {
-    data: filteredProjects,
-    totalItems: finalTotalCount,
-    totalPages: Math.ceil(finalTotalCount / limit),
+    data: projectsFromDb as PasswordOmittedProject[],
+    totalItems: totalCount,
+    totalPages: Math.ceil(totalCount / limit),
     currentPage: page,
     itemsPerPage: limit,
   };

--- a/types/project.ts
+++ b/types/project.ts
@@ -30,6 +30,15 @@ export const ProjectUpdateSchema = ProjectSchema.extend({
 export type ProjectInput = z.infer<typeof ProjectSchema>;
 export type ProjectUpdateInput = z.infer<typeof ProjectUpdateSchema>;
 
+// "all" 센티넬: 사용자가 명시적으로 "전체"를 선택했을 때만 사용.
+// URL/쿼리에서 status가 없으면 기본값(모집중)이 들어가고, "all"이면 status 필터를 건너뛴다.
+export const STATUS_FILTER_ALL = "all" as const;
+export const StatusFilterSchema = z.union([
+  z.nativeEnum(ProjectStatus),
+  z.literal(STATUS_FILTER_ALL),
+]);
+export type StatusFilter = z.infer<typeof StatusFilterSchema>;
+
 export const GetProjectsQuerySchema = z.object({
   page: z.coerce.number().int().positive().optional(),
   limit: z.coerce.number().int().positive().optional(),
@@ -39,7 +48,7 @@ export const GetProjectsQuerySchema = z.object({
   keyword: z.string().optional(),
   proposerType: z.nativeEnum(ProposerType).optional(),
   searchTerm: z.string().optional(),
-  status: z.nativeEnum(ProjectStatus).optional(),
+  status: StatusFilterSchema.optional().default(ProjectStatus.RECRUITING),
   year: z.coerce.number().int().optional(),
   semester: z.nativeEnum(Semester).optional(),
 });


### PR DESCRIPTION
## Summary

루트 페이지 진입 시 정렬·필터 UI가 활성화 안 되어 보이는 문제를 고치고, 동시에 기본 필터를 "모집중"으로 변경.

- **정렬 기본값 최신순**: `ProjectSort`의 nuqs parser에 `withDefault(LATEST)` 추가 → `/`에서 "최신순" 버튼이 active 상태로 표시. 서버는 이미 `createdDatetime desc`가 기본이라 데이터 정렬은 변경 없음.
- **상태 필터 기본값 모집중**:
  - `GetProjectsQuerySchema.status`에 `.default(ProjectStatus.RECRUITING)` 추가 + `"all"` 센티넬 도입 (전용 `StatusFilterSchema` union 추출).
  - `services/project.ts`: `status === "all"`이면 필터 스킵 (기존 `if (status)` → `if (status && status !== STATUS_FILTER_ALL)`).
  - `Filter` UI: "전체" 버튼 → `setFilter(STATUS_FILTER_ALL)` (기존 `null`). 모바일 셀렉트는 `StatusFilterSchema.safeParse`로 runtime 검증 (any 캐스트 제거).

## 동작 매트릭스

| URL | client state | API status | 서버 결과 | UI active |
|---|---|---|---|---|
| `/` | RECRUITING (default) | `RECRUITING` | 모집중만 | 모집중 |
| `?status=CLOSED` | CLOSED | `CLOSED` | 모집마감만 | 모집마감 |
| `?status=all` | "all" | `all` | 전체 | 전체 |

`nuqs withDefault`는 클라이언트 훅 반환값만 바꾸고 URL은 그대로 비워둬서, 서버가 기본값을 모를 수 있음. 그래서 zod 스키마에도 같은 default를 둬 클라이언트 `safeParseSearchParams`와 API 라우트가 모두 동일하게 동작.

## Test plan

- [ ] `/` 진입 시 "최신순" + "모집중" 탭 활성화
- [ ] "전체" 클릭 → URL `?status=all`, 모집중/마감 모두 표시
- [ ] "모집마감" 클릭 → URL `?status=CLOSED`, 모집마감만 표시
- [ ] "모집중" 클릭 → URL 클리어 (`/`), 모집중만 표시
- [ ] "인기순" 클릭 → URL `?sortBy=viewCount`, 조회수 기준 정렬
- [ ] 모바일 셀렉트에서도 동일 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)