### PR TITLE
fix(project-detail): use semantic HTML for view mode

### DIFF
--- a/app/projects/[id]/_components/ProjectTextArea.tsx
+++ b/app/projects/[id]/_components/ProjectTextArea.tsx
@@ -15,6 +15,17 @@ interface ProjectTextAreaProps {
 
 const ProjectTextArea = forwardRef<HTMLTextAreaElement, ProjectTextAreaProps>(
   ({ title, value, onChange, mode, fieldState }, ref) => {
+    if (mode === null) {
+      return (
+        <section>
+          <h3 className="w-full text-lg font-semibold">{title}</h3>
+          <p className="w-full mt-2 whitespace-pre-wrap break-words text-base">
+            {value || <span className="text-gray-400">—</span>}
+          </p>
+        </section>
+      );
+    }
+
     return (
       <div>
         <div className="w-full text-lg font-semibold">{title}</div>
@@ -23,12 +34,10 @@ const ProjectTextArea = forwardRef<HTMLTextAreaElement, ProjectTextAreaProps>(
           className={cn(
             "w-full resize-none mt-2 border p-2 rounded",
             mode === ProjectPageModeEnum.ADMIN ? "bg-gray-100" : "bg-white",
-            fieldState.error ? "border-destructive" : "border-gray-300",
-            mode === null ? "cursor-not-allowed" : "cursor-text"
+            fieldState.error ? "border-destructive" : "border-gray-300"
           )}
           value={value}
           onChange={onChange}
-          readOnly={mode === null}
         />
         {fieldState.error && (
           <p className="text-xs text-destructive mt-1">

--- a/components/Project/Form/ProjectForm.tsx
+++ b/components/Project/Form/ProjectForm.tsx
@@ -37,13 +37,13 @@ const ProjectForm = ({
         "lg:border flex flex-col w-full gap-3 lg:gap-5 rounded-lg lg:shadow-sm lg:p-5"
       )}
     >
-      <span
+      <h2
         className={cn("text-xl lg:text-2xl font-semibold", {
           hidden: withoutProjectName && mode !== ProjectPageModeEnum.ADMIN,
         })}
       >
         프로젝트 정보
-      </span>
+      </h2>
       <Separator
         className={cn("w-full lg:hidden", {
           hidden: withoutProjectName && mode !== ProjectPageModeEnum.ADMIN,

--- a/components/Project/Form/ProjectNameForm.tsx
+++ b/components/Project/Form/ProjectNameForm.tsx
@@ -19,20 +19,35 @@ const ProjectNameForm = ({
     <Controller
       name="name"
       control={control}
-      render={({ field, fieldState }) => (
-        <input
-          {...field}
-          value={field.value || ""}
-          readOnly={mode === null}
-          placeholder="프로젝트 제목"
-          className={cn(
-            "text-2xl md:text-3xl lg:text-4xl font-medium text-black w-full h-14 p-1 py-1",
-            mode === ProjectPageModeEnum.ADMIN && "bg-gray-100",
-            className,
-            fieldState.error && "border-b-destructive"
-          )}
-        />
-      )}
+      render={({ field, fieldState }) => {
+        if (mode === null) {
+          return (
+            <h1
+              className={cn(
+                "text-2xl md:text-3xl lg:text-4xl font-medium text-black w-full h-14 p-1 py-1 break-words",
+                className
+              )}
+            >
+              {field.value || (
+                <span className="text-gray-400">프로젝트 제목</span>
+              )}
+            </h1>
+          );
+        }
+        return (
+          <input
+            {...field}
+            value={field.value || ""}
+            placeholder="프로젝트 제목"
+            className={cn(
+              "text-2xl md:text-3xl lg:text-4xl font-medium text-black w-full h-14 p-1 py-1",
+              mode === ProjectPageModeEnum.ADMIN && "bg-gray-100",
+              className,
+              fieldState.error && "border-b-destructive"
+            )}
+          />
+        );
+      }}
     />
   );
 };


### PR DESCRIPTION
## 문제

프로젝트 상세페이지의 view 모드(`mode === null`)에서 본문 영역이 `readOnly` 폼 컨트롤로 렌더링되고 있었음.

- 프로젝트 제목: `<input readOnly>`
- 추진배경/실행방법/목표/기대효과/기타: `<textarea readOnly>`
- "프로젝트 정보" 묶음 제목: `<span>` (heading 아님)

### 영향
1. **a11y**: 스크린리더가 form control로 announce ("편집 가능, 읽기 전용") → 시각장애 사용자 혼란
2. **SEO**: 크롤러는 `<textarea>` value를 콘텐츠로 인덱싱하지 않음. 게다가 client component라 SSR HTML이 빈 값이라 더 안 좋음
3. **heading 계층 부재**: `<h1>` 자체가 없어서 문서 구조 신호 부재
4. **표현력 제약**: textarea는 plain text. 사용자가 본문에 줄바꿈을 넣어도 제대로 안 보이고, 향후 링크/마크다운 확장 차단됨
5. **레이아웃 hack**: `resize-none` + `field-sizing-content` + `min-h-16`으로 textarea를 본문처럼 위장 중

## 변경

`mode === null`일 때만 semantic HTML로 분기:

- `ProjectTextArea`: `<section>` + `<h3>` + `<p className="whitespace-pre-wrap break-words">`
- `ProjectNameForm`: `<h1>`
- `ProjectForm` "프로젝트 정보": `<span>` → `<h2>`

ADMIN/edit 모드의 `<textarea>`/`<input>`은 그대로 유지. react-hook-form Controller 라이프사이클 변경 없음.

## Heading 계층 (변경 후)

- `<h1>` 프로젝트 제목
- `<h2>` 프로젝트 정보
- `<h3>` 추진배경 / 실행방법 / 목표 / 기대효과 / 기타

## 검증

- [x] `npx tsc --noEmit` 통과
- [x] `next lint` 통과 (touched files)
- [ ] Vercel preview에서 view/admin 모드 양쪽 시각 확인 (이 PR로 확인 예정)

## Out of scope

- Edit 모드 `<label htmlFor>` 보강 (별도 a11y 작업)
- 본문 rich text 지원 (마크다운/링크 자동화 등) — 별도 논의
