### PR TITLE
fix: 모바일 상세 페이지 제목 줄바꿈 잘림 수정 (#116)

### DIFF
--- a/app/posts/[id]/page.tsx
+++ b/app/posts/[id]/page.tsx
@@ -87,7 +87,7 @@ const PostDetail = (props: { params: Promise<{ id: string }> }) => {
       )}
 
       {/* 헤더: 프로젝트 제목 */}
-      <h3 className="text-2xl md:text-3xl lg:text-4xl font-medium text-black w-full h-12">
+      <h3 className="text-2xl md:text-3xl lg:text-4xl font-medium text-black w-full min-h-12">
         {post.title}
       </h3>
 

--- a/app/projects/[id]/_components/Header/index.tsx
+++ b/app/projects/[id]/_components/Header/index.tsx
@@ -94,7 +94,7 @@ const ProjectDetailHeader = ({
 
       {/* 메인: 프로젝트 제목 */}
       <ProjectNameForm
-        className="h-10 md:h-12 lg:h-16 flex flex-col justify-end border-b-[1px] border-black"
+        className="min-h-10 md:min-h-12 lg:min-h-16 flex flex-col justify-end border-b-[1px] border-black"
         control={control}
         mode={mode}
       />

--- a/components/Project/Form/ProjectNameForm.tsx
+++ b/components/Project/Form/ProjectNameForm.tsx
@@ -25,7 +25,7 @@ const ProjectNameForm = ({
           return (
             <h1
               className={cn(
-                "text-2xl md:text-3xl lg:text-4xl font-medium text-black w-full h-14 p-1 py-1 break-words",
+                "text-2xl md:text-3xl lg:text-4xl font-medium text-black w-full min-h-14 p-1 py-1 break-words",
                 className
               )}
             >


### PR DESCRIPTION
Closes #116

## 변경 사항

제목 컨테이너의 고정 `h-*` 클래스를 `min-h-*` 로 변경. 한 줄짜리 제목의 시각적 높이는 유지되며, 두 줄 이상일 때만 컨테이너가 자연스럽게 늘어남.

- `components/Project/Form/ProjectNameForm.tsx` — `h1` (읽기 모드 전용): `h-14` → `min-h-14`. 편집 모드의 `<input>`은 단일 라인이므로 `h-14` 유지
- `app/projects/[id]/_components/Header/index.tsx` — 프로젝트 상세 헤더 wrapper: `h-10 md:h-12 lg:h-16` → `min-h-10 md:min-h-12 lg:min-h-16`
- `app/posts/[id]/page.tsx` — 공지 상세 `<h3>`: `h-12` → `min-h-12`

## Test plan

- [x] 모바일 폭(~375px)에서 긴 제목 프로젝트 상세 접속 → 제목 두 줄 모두 표시되는지 확인
- [x] 모바일 폭에서 긴 제목 공지 상세 접속 → 제목이 메타데이터 row와 겹치지 않는지 확인
- [x] 데스크탑(`lg`)에서 짧은 제목 케이스 → 기존 한 줄 레이아웃 유지되는지 확인
- [ ] 프로젝트 관리자 모드(편집)에서 `<input>` 한 줄 높이 그대로인지 확인
